### PR TITLE
feat: add user metrics toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Application Options:
   -m, --metrics-path=PATH          Metrics path (default: /scrape)
   -e, --xray-endpoint=HOST:PORT    Xray API endpoint (default: 127.0.0.1:8080)
   -t, --scrape-timeout=N           The timeout in seconds for every individual scrape (default: 3)
+  -u, --user-traffic-metrics       Export per-user traffic byte counters
+                                   (high cardinality: one series per user)
   -p, --log-path=PATH              Path to Xray access log file (empty to disable user metrics) 
                                    (default: /var/log/xray/access.log)
   -w, --log-time-window=N          Time window in minutes for user metrics (default: 5)
@@ -275,6 +277,8 @@ To learn more about Prometheus, please visit the [official docs](https://prometh
 | `outbound>>>tag-name>>>traffic>>>downlink` | `xray_traffic_downlink_bytes_total{dimension="outbound",target="tag-name"}` |
 | `user>>>user-email>>>traffic>>>uplink`     | `xray_traffic_uplink_bytes_total{dimension="user",target="user-email"}`    |
 | `user>>>user-email>>>traffic>>>downlink`  | `xray_traffic_downlink_bytes_total{dimension="user",target="user-email"}`  |
+
+> **Per-user traffic is opt-in.** The `dimension="user"` rows above are **not exported by default** — pass `--user-traffic-metrics` (`-u`) to enable them. Each user becomes its own series with no top-N cap, so only enable this on instances with a bounded, known set of users.
 
 ### User Activity Metrics (Log Parsing)
 

--- a/exporter.go
+++ b/exporter.go
@@ -31,6 +31,7 @@ const DefaultLogTimeWindowMinutes = 5
 type Exporter struct {
 	endpoint           string
 	scrapeTimeout      time.Duration
+	userTrafficMetrics bool
 	registry           *prometheus.Registry
 	totalScrapes       prometheus.Counter
 	metricDescriptions map[string]*prometheus.Desc
@@ -49,13 +50,14 @@ type Exporter struct {
 
 // Creates a new Xray exporter with custom log parsing configuration.
 // Pass empty logPath to disable user metrics from log parsing.
-func NewExporterWithLogConfig(endpoint string, scrapeTimeout time.Duration, logPath string, logTimeWindow time.Duration) (*Exporter, error) {
+func NewExporterWithLogConfig(endpoint string, scrapeTimeout time.Duration, userTrafficMetrics bool, logPath string, logTimeWindow time.Duration) (*Exporter, error) {
 	e := Exporter{
-		endpoint:      endpoint,
-		scrapeTimeout: scrapeTimeout,
-		registry:      prometheus.NewRegistry(),
-		logPath:       logPath,
-		logTimeWindow: logTimeWindow,
+		endpoint:           endpoint,
+		scrapeTimeout:      scrapeTimeout,
+		userTrafficMetrics: userTrafficMetrics,
+		registry:           prometheus.NewRegistry(),
+		logPath:            logPath,
+		logTimeWindow:      logTimeWindow,
 
 		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: "xray",
@@ -251,9 +253,10 @@ func (e *Exporter) scrapeXrayMetrics(ctx context.Context, ch chan<- prometheus.M
 			continue
 		}
 
-		// Skip per-user traffic metrics to control cardinality
-		// This prevents creating thousands of series for individual users
-		if p[0] == "user" {
+		// Skip per-user traffic metrics unless explicitly enabled. Per-user
+		// series are unbounded (one per user, with no top-N cap), so they stay
+		// off by default to control cardinality.
+		if p[0] == "user" && !e.userTrafficMetrics {
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ var opts struct {
 	MetricsPath            string `short:"m" long:"metrics-path" description:"Metrics path" value-name:"PATH" default:"/scrape"`
 	XRayEndpoint           string `short:"e" long:"xray-endpoint" description:"Xray API endpoint" value-name:"HOST:PORT" default:"127.0.0.1:8080"`
 	ScrapeTimeoutInSeconds int64  `short:"t" long:"scrape-timeout" description:"The timeout in seconds for every individual scrape" value-name:"N" default:"5"`
+	UserTrafficMetrics     bool   `short:"u" long:"user-traffic-metrics" description:"Export per-user traffic byte counters (high cardinality: one series per user)"`
 	LogPath                string `short:"p" long:"log-path" description:"Path to Xray access log file (empty to disable user metrics)" value-name:"PATH" default:"/var/log/xray/access.log"`
 	LogTimeWindowMinutes   int    `short:"w" long:"log-time-window" description:"Time window in minutes for user metrics" value-name:"N"`
 	GeoIPDir               string `short:"g" long:"geoip-dir" description:"Directory for GeoLite2 databases" value-name:"PATH" default:"."`
@@ -119,7 +120,7 @@ func main() {
 		timeWindowMinutes = DefaultLogTimeWindowMinutes
 	}
 	logTimeWindow := time.Duration(timeWindowMinutes) * time.Minute
-	exporter, err := NewExporterWithLogConfig(opts.XRayEndpoint, scrapeTimeout, opts.LogPath, logTimeWindow)
+	exporter, err := NewExporterWithLogConfig(opts.XRayEndpoint, scrapeTimeout, opts.UserTrafficMetrics, opts.LogPath, logTimeWindow)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create exporter")
 	}


### PR DESCRIPTION
This adds `--with-user-metrics` which enables collecting metrics for "user" dimension.

Some (private) instances of Xray serve limited amount of users.
Collecting user metrics on such instances allows for better observability in order to ensure fair use.