### PR TITLE
Add file permissions to xray-exporter entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM alpine:3.24
 RUN apk --no-cache add ca-certificates
 ARG TARGETARCH
 EXPOSE 9550
-COPY dist/xray-exporter-linux-${TARGETARCH} /usr/bin/xray-exporter
+COPY --chmod=0755 dist/xray-exporter-linux-${TARGETARCH} /usr/bin/xray-exporter
 ENTRYPOINT [ "/usr/bin/xray-exporter" ]


### PR DESCRIPTION
The binary copied from the dist folder was missing the executable bit in the container, causing entrypoint failures. Added --chmod=0755 to the COPY command to ensure the binary can run immediately.

Error in question:
```
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "/usr/bin/xray-exporter": permission denied
```