### PR TITLE
fix a batch of audit findings (reliability/perf/security)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize line endings to LF in the repository for all text files.
+* text=auto eol=lf

--- a/.github/workflows/build-release-deploy.yml
+++ b/.github/workflows/build-release-deploy.yml
@@ -7,12 +7,39 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.26'
+        cache: true
+
+    - name: Check formatting
+      run: |
+        unformatted=$(gofmt -l .)
+        if [ -n "$unformatted" ]; then
+          echo "These files are not gofmt-formatted:"
+          echo "$unformatted"
+          exit 1
+        fi
+
+    - name: Vet
+      run: go vet ./...
+
   build:
+    needs: lint
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.24
 RUN apk --no-cache add ca-certificates
 ARG TARGETARCH
 EXPOSE 9550

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An exporter that collects Xray _(and V2Ray)_ metrics over its Stats API and expo
 - **GeoIP Intelligence**: Automated Top ASNs, Countries, and Cities tracking with auto-downloading databases
 - **Outbound Routing**: Traffic distribution across different outbound connections (includes blocked requests)
 - **High Performance**: Optimized log parsing with circular buffers and LRU caching
-- **Auto-scaling**: Adaptive memory usage based on traffic patterns
+- **Adaptive buffers**: Connection buffer sized by the time window and grown lazily as traffic arrives
 - **Cross-platform**: Supports Linux, macOS, Windows with proper log rotation detection
 
 ## Quick Start
@@ -59,6 +59,7 @@ Application Options:
   -p, --log-path=PATH              Path to Xray access log file (empty to disable user metrics) 
                                    (default: /var/log/xray/access.log)
   -w, --log-time-window=N          Time window in minutes for user metrics (default: 5)
+  -g, --geoip-dir=PATH             Directory for GeoLite2 databases (default: .)
       --version                    Display the version and exit
       --log-level=LEVEL            Log level: error, warn, info, debug
                                    (env: LOG_LEVEL) (default: warn)
@@ -299,9 +300,11 @@ To learn more about Prometheus, please visit the [official docs](https://prometh
 
 Use these queries to visualize the new GeoIP metrics:
 
-- **Top 10 ASNs**: `topk(10, sum by (asn, org) (increase(xray_asns_total[$__range])))`
-- **Top 10 Countries**: `topk(10, sum by (country) (increase(xray_countries_total[$__range])))`
-- **Top 10 Cities**: `topk(10, sum by (city, country) (increase(xray_cities_total[$__range])))`
+These series are gauges (top-N request counts since the parser started, periodically trimmed), so query the value directly rather than with `rate()`/`increase()`:
+
+- **Top 10 ASNs**: `topk(10, sum by (asn, org) (xray_asns_total))`
+- **Top 10 Countries**: `topk(10, sum by (country) (xray_countries_total))`
+- **Top 10 Cities**: `topk(10, sum by (city, country) (xray_cities_total))`
 
 ## Performance & Scalability
 

--- a/exporter.go
+++ b/exporter.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/oschwald/geoip2-golang"
@@ -30,7 +29,6 @@ const DefaultLogTimeWindowMinutes = 5
 // Connects to Xray's gRPC API for runtime stats and optionally parses
 // access logs for user activity metrics.
 type Exporter struct {
-	sync.Mutex
 	endpoint           string
 	scrapeTimeout      time.Duration
 	registry           *prometheus.Registry
@@ -47,11 +45,6 @@ type Exporter struct {
 	geoipASNReader     *geoip2.Reader
 	geoipCityReader    *geoip2.Reader
 	geoipCountryReader *geoip2.Reader
-}
-
-// Creates a new Xray exporter with default settings.
-func NewExporter(endpoint string, scrapeTimeout time.Duration) (*Exporter, error) {
-	return NewExporterWithLogConfig(endpoint, scrapeTimeout, "", DefaultLogTimeWindowMinutes*time.Minute)
 }
 
 // Creates a new Xray exporter with custom log parsing configuration.
@@ -117,23 +110,22 @@ func NewExporterWithLogConfig(endpoint string, scrapeTimeout time.Duration, logP
 
 	e.conn = conn
 
-	// Initialize GeoIP readers
-	asnDB, err := geoip2.Open(geoip.ASNPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open GeoIP ASN database: %w", err)
+	// Initialize GeoIP readers. GeoIP is optional enrichment, so a missing or
+	// unreadable database is logged and skipped rather than being fatal.
+	if asnDB, err := geoip2.Open(geoip.ASNPath()); err != nil {
+		logrus.WithError(err).Warn("Failed to open GeoIP ASN database, ASN metrics will be unavailable")
+	} else {
+		e.geoipASNReader = asnDB
 	}
-	e.geoipASNReader = asnDB
 
-	cityDB, err := geoip2.Open(geoip.CityPath)
-	if err != nil {
+	if cityDB, err := geoip2.Open(geoip.CityPath()); err != nil {
 		// If city database is missing, we still continue but city/country metrics will be unknown
 		logrus.WithError(err).Warn("Failed to open GeoIP City database, city/country metrics will be unavailable")
 	} else {
 		e.geoipCityReader = cityDB
 	}
 
-	countryDB, err := geoip2.Open(geoip.CountryPath)
-	if err != nil {
+	if countryDB, err := geoip2.Open(geoip.CountryPath()); err != nil {
 		logrus.WithError(err).Warn("Failed to open GeoIP Country database, country metrics will be limited")
 	} else {
 		e.geoipCountryReader = countryDB
@@ -169,6 +161,16 @@ func NewExporterWithLogConfig(endpoint string, scrapeTimeout time.Duration, logP
 
 // Implements prometheus.Collector interface - gathers all metrics from Xray and log sources.
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
+	// A panic anywhere in collection runs in a registry-spawned goroutine that
+	// Prometheus does not recover, so it would crash the whole process. Contain
+	// it here and surface the failure as up=0 instead.
+	defer func() {
+		if r := recover(); r != nil {
+			logrus.WithField("panic", r).Error("recovered panic during metrics collection")
+			e.registerConstMetricGauge(ch, "up", 0)
+		}
+	}()
+
 	e.totalScrapes.Inc()
 	start := time.Now()
 
@@ -230,7 +232,7 @@ func (e *Exporter) scrapeXray(ch chan<- prometheus.Metric) error {
 
 // Collects traffic statistics from Xray's stats API.
 func (e *Exporter) scrapeXrayMetrics(ctx context.Context, ch chan<- prometheus.Metric, client command.StatsServiceClient) error {
-	resp, err := e.callWithRetry(func() (interface{}, error) {
+	resp, err := e.callWithRetry(ctx, func() (any, error) {
 		return client.QueryStats(ctx, &command.QueryStatsRequest{Reset_: false})
 	})
 	if err != nil {
@@ -241,6 +243,13 @@ func (e *Exporter) scrapeXrayMetrics(ctx context.Context, ch chan<- prometheus.M
 	for _, s := range statsResp.GetStat() {
 		// Parse format: inbound>>>socks-proxy>>>traffic>>>uplink
 		p := strings.Split(s.GetName(), ">>>")
+
+		// Skip names that don't match the expected 4-part format to avoid
+		// index-out-of-range panics on custom/unexpected stat names.
+		if len(p) < 4 {
+			logrus.Debugf("skipping unexpected stat name %q", s.GetName())
+			continue
+		}
 
 		// Skip per-user traffic metrics to control cardinality
 		// This prevents creating thousands of series for individual users
@@ -260,7 +269,7 @@ func (e *Exporter) scrapeXrayMetrics(ctx context.Context, ch chan<- prometheus.M
 
 // Collects system runtime metrics from Xray.
 func (e *Exporter) scrapeXraySysMetrics(ctx context.Context, ch chan<- prometheus.Metric, client command.StatsServiceClient) error {
-	resp, err := e.callWithRetry(func() (interface{}, error) {
+	resp, err := e.callWithRetry(ctx, func() (any, error) {
 		return client.GetSysStats(ctx, &command.SysStatsRequest{})
 	})
 	if err != nil {
@@ -287,7 +296,7 @@ func (e *Exporter) scrapeXraySysMetrics(ctx context.Context, ch chan<- prometheu
 
 // Implements exponential backoff retry for gRPC calls.
 // Helps handle temporary network issues or Xray restarts.
-func (e *Exporter) callWithRetry(fn func() (any, error)) (any, error) {
+func (e *Exporter) callWithRetry(ctx context.Context, fn func() (any, error)) (any, error) {
 	maxRetries := 3
 	baseDelay := 100 * time.Millisecond
 
@@ -303,7 +312,12 @@ func (e *Exporter) callWithRetry(fn func() (any, error)) (any, error) {
 
 		delay := baseDelay * time.Duration(1<<attempt)
 		logrus.WithError(err).WithField("attempt", attempt+1).WithField("delay", delay).Debug("gRPC call failed, retrying")
-		time.Sleep(delay)
+		// Honour the scrape deadline instead of blocking on a fixed sleep.
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 
 	return nil, fmt.Errorf("max retries exceeded")
@@ -379,12 +393,14 @@ func (e *Exporter) collectDomainMetrics(ch chan<- prometheus.Metric) {
 		nil,
 	)
 
-	// Only export the top domains and IPs to prevent cardinality leak
+	// Only export the top domains and IPs to prevent cardinality leak.
+	// These are gauges: the backing counts are periodically trimmed to the
+	// top-N, so the value is not monotonic and must not be treated as a counter.
 	for _, entry := range topN(e.logParser.GetDomainCounts(), logparser.MaxTrackedDomains) {
-		ch <- prometheus.MustNewConstMetric(metricDesc, prometheus.CounterValue, float64(entry.count), entry.key)
+		ch <- prometheus.MustNewConstMetric(metricDesc, prometheus.GaugeValue, float64(entry.count), entry.key)
 	}
 	for _, entry := range topN(e.logParser.GetIPCounts(), logparser.MaxTrackedIPs) {
-		ch <- prometheus.MustNewConstMetric(metricDesc, prometheus.CounterValue, float64(entry.count), entry.key)
+		ch <- prometheus.MustNewConstMetric(metricDesc, prometheus.GaugeValue, float64(entry.count), entry.key)
 	}
 }
 
@@ -401,9 +417,9 @@ func (e *Exporter) collectOutboundMetrics(ch chan<- prometheus.Metric) {
 		nil,
 	)
 
-	// Only export the top outbounds to prevent cardinality leak
+	// Only export the top outbounds to prevent cardinality leak (gauge, see note above).
 	for _, entry := range topN(e.logParser.GetOutboundCounts(), logparser.MaxTrackedOutbounds) {
-		ch <- prometheus.MustNewConstMetric(metricDesc, prometheus.CounterValue, float64(entry.count), entry.key)
+		ch <- prometheus.MustNewConstMetric(metricDesc, prometheus.GaugeValue, float64(entry.count), entry.key)
 	}
 }
 
@@ -421,7 +437,7 @@ func (e *Exporter) collectASNMetrics(ch chan<- prometheus.Metric) {
 		if len(parts) > 1 {
 			org = parts[1]
 		}
-		e.registerConstMetricCounter(ch, "asns_total", float64(entry.count), asn, org)
+		e.registerConstMetricGauge(ch, "asns_total", float64(entry.count), asn, org)
 	}
 }
 
@@ -432,7 +448,7 @@ func (e *Exporter) collectCountryMetrics(ch chan<- prometheus.Metric) {
 	}
 
 	for _, entry := range topN(e.logParser.GetCountryCounts(), logparser.MaxTrackedCountries) {
-		e.registerConstMetricCounter(ch, "countries_total", float64(entry.count), entry.key)
+		e.registerConstMetricGauge(ch, "countries_total", float64(entry.count), entry.key)
 	}
 }
 
@@ -450,7 +466,7 @@ func (e *Exporter) collectCityMetrics(ch chan<- prometheus.Metric) {
 		if len(parts) > 1 {
 			country = parts[1]
 		}
-		e.registerConstMetricCounter(ch, "cities_total", float64(entry.count), city, country)
+		e.registerConstMetricGauge(ch, "cities_total", float64(entry.count), city, country)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/xtls/xray-core v1.250608.0
+	golang.org/x/net v0.41.0
+	golang.org/x/sys v0.33.0
 	google.golang.org/grpc v1.73.0
 )
 
@@ -23,8 +25,6 @@ require (
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/sagernet/sing v0.5.1 // indirect
-	golang.org/x/net v0.41.0 // indirect
-	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect

--- a/internal/geoip/downloader.go
+++ b/internal/geoip/downloader.go
@@ -1,10 +1,12 @@
 package geoip
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -14,29 +16,80 @@ const (
 	ASNUrl     = "https://github.com/P3TERX/GeoLite.mmdb/releases/latest/download/GeoLite2-ASN.mmdb"
 	CityUrl    = "https://github.com/P3TERX/GeoLite.mmdb/releases/latest/download/GeoLite2-City.mmdb"
 	CountryUrl = "https://github.com/P3TERX/GeoLite.mmdb/releases/latest/download/GeoLite2-Country.mmdb"
-	ASNPath    = "GeoLite2-ASN.mmdb"
-	CityPath   = "GeoLite2-City.mmdb"
-	CountryPath = "GeoLite2-Country.mmdb"
+
+	asnFile     = "GeoLite2-ASN.mmdb"
+	cityFile    = "GeoLite2-City.mmdb"
+	countryFile = "GeoLite2-Country.mmdb"
+
+	// userAgent identifies this client to the upstream host.
+	userAgent = "xray-exporter (+https://github.com/compassvpn/xray-exporter)"
+
+	// dbMaxAge is how long an existing database is considered fresh enough to
+	// skip re-downloading on startup.
+	dbMaxAge = 7 * 24 * time.Hour
+
+	// downloadTimeout bounds a single download attempt.
+	downloadTimeout = 60 * time.Second
 )
 
-// DownloadDB downloads the latest GeoLite2 databases with retries.
+// Dir is the directory where GeoLite2 databases are stored and read from.
+// Override it (e.g. from a --geoip-dir flag) before calling DownloadDB.
+var Dir = "."
+
+// ASNPath returns the path to the GeoLite2 ASN database.
+func ASNPath() string { return filepath.Join(Dir, asnFile) }
+
+// CityPath returns the path to the GeoLite2 City database.
+func CityPath() string { return filepath.Join(Dir, cityFile) }
+
+// CountryPath returns the path to the GeoLite2 Country database.
+func CountryPath() string { return filepath.Join(Dir, countryFile) }
+
+// DownloadDB downloads the latest GeoLite2 databases with retries, skipping any
+// that already exist locally and are recent enough.
 func DownloadDB() error {
-	if err := downloadWithRetry("ASN", ASNUrl, ASNPath); err != nil {
-		return err
+	if err := os.MkdirAll(Dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create GeoIP directory %q: %w", Dir, err)
 	}
-	if err := downloadWithRetry("Country", CountryUrl, CountryPath); err != nil {
-		return err
+
+	client := &http.Client{Timeout: downloadTimeout}
+
+	dbs := []struct {
+		name, url, path string
+	}{
+		{"ASN", ASNUrl, ASNPath()},
+		{"Country", CountryUrl, CountryPath()},
+		{"City", CityUrl, CityPath()},
 	}
-	return downloadWithRetry("City", CityUrl, CityPath)
+
+	for _, db := range dbs {
+		if isFresh(db.path) {
+			logrus.Infof("GeoLite2-%s database is recent, skipping download", db.name)
+			continue
+		}
+		if err := downloadWithRetry(client, db.name, db.url, db.path); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-func downloadWithRetry(name, url, path string) error {
+// isFresh reports whether path exists, is non-empty, and was modified within dbMaxAge.
+func isFresh(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Size() > 0 && time.Since(info.ModTime()) < dbMaxAge
+}
+
+func downloadWithRetry(client *http.Client, name, url, path string) error {
 	maxRetries := 3
 	var lastErr error
 
 	for i := range maxRetries {
 		logrus.Infof("Downloading GeoLite2-%s database (attempt %d/%d)...", name, i+1, maxRetries)
-		err := downloadFile(path, url)
+		err := downloadFile(client, path, url)
 		if err == nil {
 			logrus.Infof("GeoLite2-%s database downloaded successfully", name)
 			return nil
@@ -49,19 +102,19 @@ func downloadWithRetry(name, url, path string) error {
 	return fmt.Errorf("failed to download GeoLite2-%s database after %d attempts: %w", name, maxRetries, lastErr)
 }
 
-func downloadFile(filepath string, url string) error {
-	// Create the file
-	out, err := os.Create(filepath)
+// downloadFile streams url to a temp file in the same directory and atomically
+// renames it into place, so a failed download never corrupts an existing DB.
+func downloadFile(client *http.Client, path, url string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	req.Header.Set("User-Agent", userAgent)
 
-	// Get the data
-	client := &http.Client{
-		Timeout: 60 * time.Second,
-	}
-	resp, err := client.Get(url)
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -71,7 +124,20 @@ func downloadFile(filepath string, url string) error {
 		return fmt.Errorf("bad status: %s", resp.Status)
 	}
 
-	// Write the body to file
-	_, err = io.Copy(out, resp.Body)
-	return err
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op once the rename below succeeds
+
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpName, path)
 }

--- a/internal/logparser/filter.go
+++ b/internal/logparser/filter.go
@@ -3,27 +3,29 @@
 package logparser
 
 import (
+	"container/list"
 	"net"
 	"sync"
 )
 
 // Efficiently filters out unwanted IP addresses from metrics collection.
 // Uses multiple strategies: exact matches for system IPs, network ranges for private IPs,
-// and an LRU cache to avoid repeated expensive lookups.
+// and an LRU cache (O(1) eviction) to avoid repeated expensive lookups.
 type IPFilter struct {
-	systemIPs    map[string]bool       // Known system/localhost addresses
-	dnsServers   map[string]bool       // Common public DNS servers
-	privateNets  []*net.IPNet          // Private network ranges (RFC 1918, etc.)
-	cache        map[string]cacheEntry // LRU cache for filter results
-	cacheMu      sync.RWMutex          // Protects cache access
-	maxCacheSize int                   // Maximum cache entries before eviction
-	cacheCounter uint64                // Counter for LRU tracking
+	systemIPs   map[string]bool // Known system/localhost addresses
+	dnsServers  map[string]bool // Common public DNS servers
+	privateNets []*net.IPNet    // Private network ranges (RFC 1918, etc.)
+
+	mu           sync.Mutex               // Protects the LRU cache
+	cache        map[string]*list.Element // ip -> element in lru
+	lru          *list.List               // most-recently-used at the front
+	maxCacheSize int                      // Maximum cache entries before eviction
 }
 
-// Stores a filter result with LRU tracking information.
-type cacheEntry struct {
-	result   bool   // Whether this IP should be filtered
-	lastUsed uint64 // LRU counter value when last accessed
+// Stores a cached filter result for one IP.
+type cacheItem struct {
+	ip     string
+	result bool
 }
 
 // Creates a new IP filter with predefined lists of addresses to exclude.
@@ -32,9 +34,9 @@ func NewIPFilter() *IPFilter {
 	filter := &IPFilter{
 		systemIPs:    make(map[string]bool),
 		dnsServers:   make(map[string]bool),
-		cache:        make(map[string]cacheEntry),
+		cache:        make(map[string]*list.Element),
+		lru:          list.New(),
 		maxCacheSize: 100000,
-		cacheCounter: 0,
 	}
 
 	// System and localhost addresses
@@ -94,51 +96,37 @@ func NewIPFilter() *IPFilter {
 }
 
 // Returns true if the IP address should be excluded from user metrics.
-// Uses an LRU cache to avoid repeated expensive network checks for the same IPs.
+// Uses an LRU cache (O(1) lookup and eviction) to avoid repeated network checks.
 func (f *IPFilter) ShouldFilter(ip string) bool {
-	// Check cache first for fast path
-	f.cacheMu.RLock()
-	if entry, exists := f.cache[ip]; exists {
-		f.cacheMu.RUnlock()
-
-		// Update access time atomically for LRU tracking
-		f.cacheMu.Lock()
-		f.cacheCounter++
-		entry.lastUsed = f.cacheCounter
-		f.cache[ip] = entry
-		f.cacheMu.Unlock()
-
-		return entry.result
+	f.mu.Lock()
+	if el, ok := f.cache[ip]; ok {
+		f.lru.MoveToFront(el)
+		result := el.Value.(*cacheItem).result
+		f.mu.Unlock()
+		return result
 	}
-	f.cacheMu.RUnlock()
+	f.mu.Unlock()
 
-	// Perform actual filtering logic
+	// Perform actual filtering logic (no lock needed; reads immutable data).
 	result := f.shouldFilterInternal(ip)
 
-	// Update cache with result
-	f.cacheMu.Lock()
-	defer f.cacheMu.Unlock()
-
-	// Implement LRU eviction when cache is full
-	if len(f.cache) >= f.maxCacheSize {
-		// Find and remove the least recently used entry
-		var oldestIP string
-		var oldestTime uint64 = ^uint64(0) // Max uint64
-
-		for cachedIP, entry := range f.cache {
-			if entry.lastUsed < oldestTime {
-				oldestTime = entry.lastUsed
-				oldestIP = cachedIP
+	f.mu.Lock()
+	if el, ok := f.cache[ip]; ok {
+		// Inserted by a concurrent caller in the meantime; just refresh it.
+		f.lru.MoveToFront(el)
+		el.Value.(*cacheItem).result = result
+	} else {
+		f.cache[ip] = f.lru.PushFront(&cacheItem{ip: ip, result: result})
+		// Evict the least-recently-used entry in O(1) when over capacity.
+		if f.lru.Len() > f.maxCacheSize {
+			if oldest := f.lru.Back(); oldest != nil {
+				f.lru.Remove(oldest)
+				delete(f.cache, oldest.Value.(*cacheItem).ip)
 			}
 		}
-
-		if oldestIP != "" {
-			delete(f.cache, oldestIP)
-		}
 	}
+	f.mu.Unlock()
 
-	f.cacheCounter++
-	f.cache[ip] = cacheEntry{result: result, lastUsed: f.cacheCounter}
 	return result
 }
 

--- a/internal/logparser/inode_unix.go
+++ b/internal/logparser/inode_unix.go
@@ -12,7 +12,7 @@ import (
 // Returns the inode number of a file on Unix systems.
 // Inodes are unique identifiers that help detect when log files are rotated or replaced.
 // Returns 0 if the inode cannot be determined (rare on Unix systems).
-func getInode(fileInfo os.FileInfo) uint64 {
+func getInode(_ *os.File, fileInfo os.FileInfo) uint64 {
 	if stat, ok := fileInfo.Sys().(*syscall.Stat_t); ok {
 		return stat.Ino
 	}

--- a/internal/logparser/inode_windows.go
+++ b/internal/logparser/inode_windows.go
@@ -1,19 +1,27 @@
 //go:build windows
 
 // Cross-platform file tracking functionality.
-// This Windows implementation uses modification time as a fallback since Windows
-// doesn't have Unix-style inodes.
+// This Windows implementation uses the NTFS file index (a stable per-file id,
+// the closest equivalent to a Unix inode) so that appending to a log file is
+// NOT mistaken for a rotation. ModTime is only used as a last-resort fallback.
 package logparser
 
 import (
 	"os"
+
+	"golang.org/x/sys/windows"
 )
 
-// Returns a file identifier for Windows systems.
-// Since Windows doesn't have inodes like Unix systems, we use the file's
-// modification time as a unique identifier. This works for log rotation detection
-// because rotated files typically have different timestamps.
-func getInode(fileInfo os.FileInfo) uint64 {
-	// Windows doesn't have inodes, use modification time as unique identifier
+// Returns a stable file identifier for Windows systems.
+// It reads the NTFS file index via GetFileInformationByHandle, which (unlike
+// ModTime) does not change when the file is appended to, so an actively-written
+// log is not repeatedly re-read from the start.
+func getInode(file *os.File, fileInfo os.FileInfo) uint64 {
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(windows.Handle(file.Fd()), &info); err == nil {
+		return uint64(info.FileIndexHigh)<<32 | uint64(info.FileIndexLow)
+	}
+	// Fallback for filesystems without a stable file index (e.g. some FAT/network
+	// shares): use ModTime. This may over-detect rotation but never under-detects.
 	return uint64(fileInfo.ModTime().UnixNano())
 }

--- a/internal/logparser/parser.go
+++ b/internal/logparser/parser.go
@@ -7,18 +7,19 @@ import (
 	"bufio"
 	"cmp"
 	"context"
-	"fmt"
 	"maps"
 	"net"
 	"os"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/oschwald/geoip2-golang"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/net/publicsuffix"
 )
 
 // Cardinality limits to prevent excessive metric series
@@ -44,7 +45,6 @@ type LogEntry struct {
 	Timestamp time.Time
 	IP        string
 	ParsedIP  net.IP
-	Domain    string
 }
 
 // Holds collected metrics for a specified time window.
@@ -58,10 +58,12 @@ type MetricsData struct {
 	CountryCounts  map[string]int64     // country -> total request count (labels: country)
 	CityCounts     map[string]int64     // city -> total request count (labels: city, country)
 
-	// Circular buffer for connection timestamps to limit memory usage
+	// Circular buffer for connection timestamps to limit memory usage.
+	// The backing slice grows lazily up to ConnectionsBufCap so low-traffic
+	// servers don't pay the full allocation upfront.
 	ConnectionTimestamps []time.Time // circular buffer of connection timestamps
 	ConnectionsBufHead   int         // current write position in buffer
-	ConnectionsBufSize   int         // actual size of valid data in buffer
+	ConnectionsBufSize   int         // number of in-window entries currently held
 	ConnectionsBufCap    int         // maximum buffer capacity
 
 	LastPos   int64  // last position read in log file
@@ -103,6 +105,32 @@ var (
 	outboundRegex    = regexp.MustCompile(`\[[^\]]*?(?:->|>>)\s*([^\]]+?)\]`)
 )
 
+// metricsDelta accumulates a batch of parsed results so the expensive parsing
+// and GeoIP lookups can run WITHOUT holding the metrics lock. The deltas are
+// merged into the shared MetricsData under a brief lock at the end of a batch.
+type metricsDelta struct {
+	domainCounts   map[string]int64
+	ipCounts       map[string]int64
+	outboundCounts map[string]int64
+	asnCounts      map[string]int64
+	countryCounts  map[string]int64
+	cityCounts     map[string]int64
+	uniqueIPs      map[string]time.Time
+	timestamps     []time.Time
+}
+
+func newMetricsDelta() *metricsDelta {
+	return &metricsDelta{
+		domainCounts:   make(map[string]int64),
+		ipCounts:       make(map[string]int64),
+		outboundCounts: make(map[string]int64),
+		asnCounts:      make(map[string]int64),
+		countryCounts:  make(map[string]int64),
+		cityCounts:     make(map[string]int64),
+		uniqueIPs:      make(map[string]time.Time),
+	}
+}
+
 // Performs quick checks to skip obviously invalid lines before expensive parsing.
 // Improves performance by filtering out non-log lines early.
 func shouldSkipLine(line string) bool {
@@ -129,14 +157,19 @@ func shouldSkipLine(line string) bool {
 	return false
 }
 
-// Extracts the root domain from a full domain name.
-// Example: sub.google.com -> google.com
+// Extracts the registrable (eTLD+1) domain from a full domain name, using the
+// public suffix list so multi-part suffixes are handled correctly.
+// Example: a.sub.example.co.uk -> example.co.uk
 func getRootDomain(domain string) string {
 	if domain == "" {
 		return ""
 	}
 
-	// Handle domain names - extract root domain
+	if etld1, err := publicsuffix.EffectiveTLDPlusOne(domain); err == nil && etld1 != "" {
+		return etld1
+	}
+
+	// Fallback: last two labels.
 	parts := strings.Split(domain, ".")
 	if len(parts) >= 2 {
 		return parts[len(parts)-2] + "." + parts[len(parts)-1]
@@ -155,12 +188,18 @@ func extractOutbound(line string) string {
 }
 
 // Adds a timestamp to the circular buffer.
-// Prevents memory growth by overwriting old entries when the buffer is full.
+// The backing slice grows lazily up to the cap, then overwrites the oldest entry.
 func (p *Parser) addConnectionTimestamp(ts time.Time) {
-	p.metrics.ConnectionTimestamps[p.metrics.ConnectionsBufHead] = ts
-	p.metrics.ConnectionsBufHead = (p.metrics.ConnectionsBufHead + 1) % p.metrics.ConnectionsBufCap
-	if p.metrics.ConnectionsBufSize < p.metrics.ConnectionsBufCap {
-		p.metrics.ConnectionsBufSize++
+	m := p.metrics
+	if m.ConnectionsBufHead == len(m.ConnectionTimestamps) && len(m.ConnectionTimestamps) < m.ConnectionsBufCap {
+		// Still growing the backing array.
+		m.ConnectionTimestamps = append(m.ConnectionTimestamps, ts)
+	} else {
+		m.ConnectionTimestamps[m.ConnectionsBufHead] = ts
+	}
+	m.ConnectionsBufHead = (m.ConnectionsBufHead + 1) % m.ConnectionsBufCap
+	if m.ConnectionsBufSize < m.ConnectionsBufCap {
+		m.ConnectionsBufSize++
 	}
 }
 
@@ -230,21 +269,25 @@ func keepTopN(counts map[string]int64, n int) map[string]int64 {
 func NewParser(config Config) (*Parser, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Calculate buffer capacity automatically based on time window
-	// Use adaptive sizing: more time = bigger buffer, with sensible bounds
+	// Calculate buffer capacity automatically based on time window.
+	// The buffer is a cap, not an upfront allocation: it grows lazily with
+	// actual traffic (see addConnectionTimestamp).
 	minutes := int(config.TimeWindow.Minutes())
 
 	var bufferCap int
 	switch {
 	case minutes <= 5:
-		bufferCap = 500000 // Short windows: 500K entries (~12MB)
+		bufferCap = 500000 // Short windows: up to 500K entries (~12MB)
 	case minutes <= 10:
-		bufferCap = 1000000 // Medium windows: 1M entries (~24MB)
+		bufferCap = 1000000 // Medium windows: up to 1M entries (~24MB)
 	case minutes <= 30:
-		bufferCap = 2000000 // Long windows: 2M entries (~48MB)
+		bufferCap = 2000000 // Long windows: up to 2M entries (~48MB)
 	default:
-		bufferCap = 5000000 // Very long windows: 5M entries (~120MB)
+		bufferCap = 5000000 // Very long windows: up to 5M entries (~120MB)
 	}
+
+	// Start small and let the buffer grow with traffic.
+	initialCap := min(bufferCap, 1024)
 
 	parser := &Parser{
 		logPath:       config.LogPath,
@@ -261,7 +304,7 @@ func NewParser(config Config) (*Parser, error) {
 			ASNCounts:            make(map[string]int64),
 			CountryCounts:        make(map[string]int64),
 			CityCounts:           make(map[string]int64),
-			ConnectionTimestamps: make([]time.Time, bufferCap),
+			ConnectionTimestamps: make([]time.Time, 0, initialCap),
 			ConnectionsBufHead:   0,
 			ConnectionsBufSize:   0,
 			ConnectionsBufCap:    bufferCap,
@@ -269,9 +312,6 @@ func NewParser(config Config) (*Parser, error) {
 		ctx:    ctx,
 		cancel: cancel,
 	}
-
-	// Immediate cleanup on startup to ensure clean state
-	parser.trimToTopN()
 
 	return parser, nil
 }
@@ -311,23 +351,22 @@ func (p *Parser) GetMetrics() (int, int64) {
 		delete(p.metrics.UniqueIPs, ip)
 	}
 
-	// Count valid connections in circular buffer
-	var validConnections int64
-	for i := 0; i < p.metrics.ConnectionsBufSize; i++ {
-		idx := (p.metrics.ConnectionsBufHead - i - 1 + p.metrics.ConnectionsBufCap) % p.metrics.ConnectionsBufCap
-		if p.metrics.ConnectionTimestamps[idx].After(cutoff) {
-			validConnections++
-		} else {
-			// Since we store in chronological order, older entries won't be valid either
+	// Expire connection timestamps from the oldest end. Because entries are
+	// stored chronologically, we only walk the newly-expired tail, and the
+	// remaining size IS the in-window connection count (amortized O(1)).
+	bufCap := p.metrics.ConnectionsBufCap
+	for p.metrics.ConnectionsBufSize > 0 {
+		tail := ((p.metrics.ConnectionsBufHead-p.metrics.ConnectionsBufSize)%bufCap + bufCap) % bufCap
+		if p.metrics.ConnectionTimestamps[tail].After(cutoff) {
 			break
 		}
+		p.metrics.ConnectionsBufSize--
 	}
 
-	return activeIPs, validConnections
+	return activeIPs, int64(p.metrics.ConnectionsBufSize)
 }
 
 // Returns a copy of current domain request counts.
-// These are cumulative counters since parser startup.
 func (p *Parser) GetDomainCounts() map[string]int64 {
 	p.metrics.mu.RLock()
 	defer p.metrics.mu.RUnlock()
@@ -344,7 +383,6 @@ func (p *Parser) GetIPCounts() map[string]int64 {
 }
 
 // Returns a copy of current outbound request counts.
-// These are cumulative counters since parser startup.
 func (p *Parser) GetOutboundCounts() map[string]int64 {
 	p.metrics.mu.RLock()
 	defer p.metrics.mu.RUnlock()
@@ -416,153 +454,179 @@ func (p *Parser) parseLogFile() error {
 	}
 
 	p.mu.Lock()
-	currentInode := getInode(stat)
+	currentInode := getInode(file, stat)
 
-	// Check for log rotation by comparing inodes
-	if currentInode != p.metrics.LastInode {
+	switch {
+	case p.metrics.LastInode == 0:
+		// First run: adopt the current file identity, keep position (0).
+		p.metrics.LastInode = currentInode
+	case currentInode != p.metrics.LastInode:
 		logrus.Debug("Log file rotated, resetting position")
 		p.metrics.LastPos = 0
 		p.metrics.LastInode = currentInode
-	}
-
-	// Handle file truncation (file got smaller)
-	if p.metrics.LastPos > stat.Size() {
+	case p.metrics.LastPos > stat.Size():
 		logrus.Debug("Log file truncated, resetting position")
 		p.metrics.LastPos = 0
 	}
 
-	// Initialize tracking on first run
-	if p.metrics.LastInode == 0 {
-		p.metrics.LastPos = 0
-		p.metrics.LastInode = currentInode
-	}
-
-	// Seek to last known position
-	if _, err := file.Seek(p.metrics.LastPos, 0); err != nil {
-		p.mu.Unlock()
-		return err
-	}
+	startPos := p.metrics.LastPos
 	p.mu.Unlock()
 
-	scanner := bufio.NewScanner(file)
-	cutoff := time.Now().Add(-p.timeWindow)
-	newPos := p.metrics.LastPos
-
-	p.metrics.mu.Lock()
-	defer p.metrics.mu.Unlock()
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		newPos += int64(len(line)) + 1 // +1 for newline
-
-		// Quick pre-filtering to skip obviously invalid lines
-		if shouldSkipLine(line) {
-			continue
-		}
-
-		entry, err := p.parseLine(line)
-		if err != nil || entry == nil {
-			continue
-		}
-
-		// Always track domain and IP requests (cumulative counters)
-		originalDomain := extractDomainOptimized(line)
-		if originalDomain != "" {
-			if isIPAddressFast(originalDomain) {
-				// Normalize and exclude system/DNS/private IPs
-				normalized := normalizeIP(originalDomain)
-				if normalized != "" && !p.ipFilter.ShouldFilter(normalized) {
-					p.metrics.IPCounts[normalized]++
-				}
-			} else {
-				// Track domain requests (root domain)
-				rootDomain := getRootDomain(originalDomain)
-				if rootDomain != "" {
-					p.metrics.DomainCounts[rootDomain]++
-				}
-			}
-		}
-
-		// Always track outbound requests (cumulative counters)
-		outbound := extractOutbound(line)
-		if outbound != "" {
-			p.metrics.OutboundCounts[outbound]++
-		}
-
-		// Skip entries outside time window (for user metrics only)
-		if entry.Timestamp.Before(cutoff) {
-			continue
-		}
-
-		// Filter out internal/system IPs
-		if p.ipFilter.ShouldFilter(entry.IP) {
-			continue
-		}
-
-		// Update user metrics (time-windowed)
-		p.addConnectionTimestamp(entry.Timestamp)
-		// Track unique IPs with last seen time
-		p.metrics.UniqueIPs[entry.IP] = entry.Timestamp
-
-		// Extract context for detailed tracking
-		countryCode := "unknown"
-		cityName := "unknown"
-		asn := "unknown"
-		org := "unknown"
-
-		// Detailed GeoIP lookups
-		if p.cityReader != nil {
-			if record, err := p.cityReader.City(entry.ParsedIP); err == nil {
-				if record.Country.IsoCode != "" {
-					countryCode = record.Country.IsoCode
-				}
-				if name, ok := record.City.Names["en"]; ok && name != "" {
-					cityName = name
-				}
-			}
-		} else if p.countryReader != nil {
-			if record, err := p.countryReader.Country(entry.ParsedIP); err == nil {
-				if record.Country.IsoCode != "" {
-					countryCode = record.Country.IsoCode
-				}
-			}
-		}
-
-		if p.asnReader != nil {
-			if record, err := p.asnReader.ASN(entry.ParsedIP); err == nil {
-				asn = fmt.Sprintf("%d", record.AutonomousSystemNumber)
-				org = record.AutonomousSystemOrganization
-			}
-		}
-
-		// Update aggregated metrics
-		if countryCode != "unknown" {
-			p.metrics.CountryCounts[countryCode]++
-		}
-		if cityName != "unknown" {
-			cityKey := fmt.Sprintf("%s|%s", cityName, countryCode)
-			p.metrics.CityCounts[cityKey]++
-		}
-
-		// Update Detailed ASN tracking (consolidated metric)
-		// Key format: asn|org
-		asnKey := fmt.Sprintf("%s|%s", asn, org)
-		p.metrics.ASNCounts[asnKey]++
+	// Seek to last known position
+	if _, err := file.Seek(startPos, 0); err != nil {
+		return err
 	}
 
-	// Update file position for next read
+	cutoff := time.Now().Add(-p.timeWindow)
+	newPos := startPos
+	delta := newMetricsDelta()
+
+	// bufio.Reader (not Scanner) avoids the 64KB line cap and lets us track the
+	// exact number of bytes consumed (including \r and \n), so the position never
+	// drifts on CRLF logs.
+	reader := bufio.NewReader(file)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			// io.EOF (or any read error): a trailing line without a newline is a
+			// partial write; stop without consuming it so it is re-read once
+			// complete on the next pass.
+			break
+		}
+		newPos += int64(len(line))
+		p.processLine(strings.TrimRight(line, "\r\n"), cutoff, delta)
+	}
+
+	// Merge the batch under the metrics lock. No parsing or I/O happens here,
+	// so scrapes are only blocked for the duration of a few map merges.
+	p.metrics.mu.Lock()
+	p.mergeDelta(delta)
+	p.metrics.mu.Unlock()
+
+	// Update file position for next read.
 	p.mu.Lock()
 	p.metrics.LastPos = newPos
 	p.mu.Unlock()
 
-	return scanner.Err()
+	return nil
 }
 
-// Parses a single log line with optimized string operations.
-// Extracts timestamp, IP address, domain, and blocked status.
-func (p *Parser) parseLine(line string) (*LogEntry, error) {
-	entry := &LogEntry{}
+// processLine parses a single log line and records its data into delta.
+// It performs no shared-state mutation (the IP filter and GeoIP readers are
+// safe for concurrent use), so it can run without holding the metrics lock.
+func (p *Parser) processLine(line string, cutoff time.Time, delta *metricsDelta) {
+	// Quick pre-filtering to skip obviously invalid lines
+	if shouldSkipLine(line) {
+		return
+	}
 
+	entry, err := p.parseLine(line)
+	if err != nil || entry == nil {
+		return
+	}
+
+	// Always track domain and IP requests.
+	if domain := extractDomainOptimized(line); domain != "" {
+		if isIPAddressFast(domain) {
+			// Normalize and exclude system/DNS/private IPs.
+			if normalized := normalizeIP(domain); normalized != "" && !p.ipFilter.ShouldFilter(normalized) {
+				delta.ipCounts[normalized]++
+			}
+		} else if rootDomain := getRootDomain(domain); rootDomain != "" {
+			delta.domainCounts[rootDomain]++
+		}
+	}
+
+	// Always track outbound requests.
+	if outbound := extractOutbound(line); outbound != "" {
+		delta.outboundCounts[outbound]++
+	}
+
+	// Skip entries outside time window (for user metrics only).
+	if entry.Timestamp.Before(cutoff) {
+		return
+	}
+
+	// Filter out internal/system IPs.
+	if p.ipFilter.ShouldFilter(entry.IP) {
+		return
+	}
+
+	// Update user metrics (time-windowed).
+	delta.timestamps = append(delta.timestamps, entry.Timestamp)
+	delta.uniqueIPs[entry.IP] = entry.Timestamp
+
+	// Extract context for detailed tracking.
+	countryCode := "unknown"
+	cityName := "unknown"
+	asn := "unknown"
+	org := "unknown"
+
+	if p.cityReader != nil {
+		if record, err := p.cityReader.City(entry.ParsedIP); err == nil {
+			if record.Country.IsoCode != "" {
+				countryCode = record.Country.IsoCode
+			}
+			if name, ok := record.City.Names["en"]; ok && name != "" {
+				cityName = name
+			}
+		}
+	} else if p.countryReader != nil {
+		if record, err := p.countryReader.Country(entry.ParsedIP); err == nil {
+			if record.Country.IsoCode != "" {
+				countryCode = record.Country.IsoCode
+			}
+		}
+	}
+
+	if p.asnReader != nil {
+		if record, err := p.asnReader.ASN(entry.ParsedIP); err == nil {
+			asn = strconv.FormatUint(uint64(record.AutonomousSystemNumber), 10)
+			org = record.AutonomousSystemOrganization
+		}
+	}
+
+	// Update aggregated metrics.
+	if countryCode != "unknown" {
+		delta.countryCounts[countryCode]++
+	}
+	if cityName != "unknown" {
+		delta.cityCounts[cityName+"|"+countryCode]++
+	}
+	// Key format: asn|org
+	delta.asnCounts[asn+"|"+org]++
+}
+
+// mergeDelta folds a parsed batch into the shared metrics. Caller must hold metrics.mu.
+func (p *Parser) mergeDelta(d *metricsDelta) {
+	for k, v := range d.domainCounts {
+		p.metrics.DomainCounts[k] += v
+	}
+	for k, v := range d.ipCounts {
+		p.metrics.IPCounts[k] += v
+	}
+	for k, v := range d.outboundCounts {
+		p.metrics.OutboundCounts[k] += v
+	}
+	for k, v := range d.asnCounts {
+		p.metrics.ASNCounts[k] += v
+	}
+	for k, v := range d.countryCounts {
+		p.metrics.CountryCounts[k] += v
+	}
+	for k, v := range d.cityCounts {
+		p.metrics.CityCounts[k] += v
+	}
+	for ip, ts := range d.uniqueIPs {
+		p.metrics.UniqueIPs[ip] = ts
+	}
+	for _, ts := range d.timestamps {
+		p.addConnectionTimestamp(ts)
+	}
+}
+
+// Parses a single log line, extracting timestamp and client IP.
+func (p *Parser) parseLine(line string) (*LogEntry, error) {
 	// Parse timestamp
 	timestampMatch := timestampRegex.FindStringSubmatch(line)
 	if len(timestampMatch) < 2 {
@@ -573,7 +637,6 @@ func (p *Parser) parseLine(line string) (*LogEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	entry.Timestamp = timestamp
 
 	// Extract IP with single pass through formats
 	var ip string
@@ -591,28 +654,17 @@ func (p *Parser) parseLine(line string) (*LogEntry, error) {
 		return nil, nil // Skip lines without IP
 	}
 
-	// Normalize IP once and reuse result
-	normalizedIP := normalizeIP(ip)
-	if normalizedIP == "" {
+	// Normalize and parse the IP once, reusing the parsed value.
+	normalizedIP, parsedIP := normalizeIPParsed(ip)
+	if parsedIP == nil {
 		return nil, nil // Skip invalid IPs
 	}
-	entry.IP = normalizedIP
-	entry.ParsedIP = net.ParseIP(normalizedIP)
 
-	// Extract domain for entry (just for reference, actual tracking done later)
-	// Use optimized domain extraction that reuses already parsed line components
-	domain := extractDomainOptimized(line)
-	if domain != "" {
-		// Check if it's an IP by testing if it's the same as our normalized IP
-		// This avoids calling net.ParseIP again
-		if domain == normalizedIP || isIPAddressFast(domain) {
-			entry.Domain = domain // Keep IP as-is
-		} else {
-			entry.Domain = getRootDomain(domain) // Store root domain
-		}
-	}
-
-	return entry, nil
+	return &LogEntry{
+		Timestamp: timestamp,
+		IP:        normalizedIP,
+		ParsedIP:  parsedIP,
+	}, nil
 }
 
 // Performs a quick heuristic check for IP addresses without full parsing.
@@ -666,32 +718,20 @@ func extractDomainOptimized(line string) string {
 	return domainPort[:colonIdx]
 }
 
-// Normalizes an IP address string.
-func normalizeIP(ip string) string {
+// normalizeIPParsed canonicalizes an IP address string and returns both the
+// canonical string form and the parsed net.IP, so callers don't parse twice.
+func normalizeIPParsed(ip string) (string, net.IP) {
 	ip = strings.Trim(ip, "[]")
 
 	if parsed := net.ParseIP(ip); parsed != nil {
-		return parsed.String()
+		return parsed.String(), parsed
 	}
 
-	return ""
+	return "", nil
 }
 
-// getSubnet24 masks an IP address to its /24 prefix (IPv4) or /48 prefix (IPv6).
-func getSubnet24(ip net.IP) string {
-	if ip == nil {
-		return ""
-	}
-
-	if ipv4 := ip.To4(); ipv4 != nil {
-		// IPv4: mask to /24 (first 3 bytes)
-		return fmt.Sprintf("%d.%d.%d.0/24", ipv4[0], ipv4[1], ipv4[2])
-	}
-
-	// IPv6: mask to /48 (first 6 bytes) as a sensible equivalent for aggregation
-	if len(ip) >= 6 {
-		return fmt.Sprintf("%02x%02x:%02x%02x:%02x%02x::/48",
-			ip[0], ip[1], ip[2], ip[3], ip[4], ip[5])
-	}
-	return ""
+// Normalizes an IP address string, returning "" if it is not a valid IP.
+func normalizeIP(ip string) string {
+	s, _ := normalizeIPParsed(ip)
+	return s
 }

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var opts struct {
 	ScrapeTimeoutInSeconds int64  `short:"t" long:"scrape-timeout" description:"The timeout in seconds for every individual scrape" value-name:"N" default:"5"`
 	LogPath                string `short:"p" long:"log-path" description:"Path to Xray access log file (empty to disable user metrics)" value-name:"PATH" default:"/var/log/xray/access.log"`
 	LogTimeWindowMinutes   int    `short:"w" long:"log-time-window" description:"Time window in minutes for user metrics" value-name:"N"`
+	GeoIPDir               string `short:"g" long:"geoip-dir" description:"Directory for GeoLite2 databases" value-name:"PATH" default:"."`
 	Version                bool   `long:"version" description:"Display the version and exit"`
 	LogLevel               string `long:"log-level" description:"Log level: error, warn, info, debug (env: LOG_LEVEL) (default: warn)" value-name:"LEVEL"`
 }
@@ -102,9 +103,11 @@ func main() {
 		return
 	}
 
-	// Download GeoLite2 databases on startup
+	// Download GeoLite2 databases on startup. GeoIP is optional enrichment, so a
+	// download failure is non-fatal: the exporter still serves core gRPC metrics.
+	geoip.Dir = opts.GeoIPDir
 	if err := geoip.DownloadDB(); err != nil {
-		logrus.WithError(err).Fatal("Failed to initialize GeoIP database")
+		logrus.WithError(err).Warn("Failed to initialize GeoIP database, GeoIP metrics will be unavailable")
 	}
 
 	// Initialize exporter with configuration
@@ -150,18 +153,26 @@ func main() {
 		IdleTimeout:  120 * time.Second,
 	}
 
-	// Start server in background
+	// Start server in background; a startup failure is routed back to main so the
+	// deferred cleanup (exporter.Close) still runs instead of os.Exit-ing here.
+	serverErr := make(chan error, 1)
 	go func() {
 		logrus.Infof("Server starting on %s", opts.Listen)
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logrus.WithError(err).Fatal("Server failed to start")
+			serverErr <- err
 		}
 	}()
 
-	// Wait for shutdown signal
+	// Wait for a shutdown signal or a server startup error.
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	<-quit
+
+	select {
+	case err := <-serverErr:
+		logrus.WithError(err).Error("Server failed to start")
+		return
+	case <-quit:
+	}
 
 	logrus.Info("Shutting down server...")
 


### PR DESCRIPTION
Batch of fixes from a perf/security/reliability audit. No dependency version bumps; builds + vets clean on linux/windows/darwin.

### High
- **Windows log rotation**: detect rotation via the NTFS file index instead of ModTime. Before, every append looked like a rotation, so the whole log was re-read every 5s and all counters inflated without bound.
- **Crash-proof Collect**: guard the `>>>` stat-name split (`len(p) < 4`) and add a `recover()` in `Collect`. An unexpected Xray stat name was an index panic, and Prometheus runs `Collect` in an unrecovered goroutine → whole process down.

### Medium
- GeoIP download failure is now non-fatal (core gRPC metrics still start); ASN db open is non-fatal too.
- domain/ip/outbound/asn/country/city series are **gauges**, not counters — the periodic top-N trim reset them, which broke `rate()`/`increase()`. (Grafana query notes updated.)
- Parse + GeoIP lookups happen off-lock into local deltas, merged under a brief lock — scrapes no longer block on the parse loop.

### Low
- `bufio.Reader` instead of `Scanner`: no 64KB line cap, exact byte offsets (fixes CRLF position drift).
- Connection buffer grows lazily up to its cap; in-window count is now O(1).
- `publicsuffix` for root domains (`a.example.co.uk` → `example.co.uk`, not `co.uk`).
- O(1) `container/list` LRU in the IP filter (was an O(n) scan per eviction).
- GeoIP downloader: temp file + atomic rename, skip-if-recent, request context + User-Agent, new `--geoip-dir` flag.
- Removed dead code (`getSubnet24`, `NewExporter`, unused embedded `sync.Mutex`).
- Context-aware retry backoff; bind errors routed through `main` so cleanup runs.
- Pin `alpine:3.24`; CI top-level `permissions: contents: read` + a `gofmt`/`vet` gate.
- Normalize line endings to LF via `.gitattributes` (most of the diff is this).

Not included (not selected): M3 unauth endpoints, M4 GeoIP checksum/pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)