### PR TITLE
docs: add a one-command pre-commit check to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,20 @@ This exporter is optimized for high-traffic proxy services:
 - **Concurrent Safe**: Lock-free operations where possible, minimal lock contention
 - **Production Ready**: Handles log rotation, file truncation, and network failures gracefully
 
+## Development
+
+Before committing, run this single command to format, vet, and build the
+project. It mirrors the checks CI runs, so if it passes locally the lint gate
+will pass too:
+
+```bash
+gofmt -w . && go vet ./... && go build ./...
+```
+
+- `gofmt -w .` rewrites any mis-formatted files in place
+- `go vet ./...` catches common mistakes
+- `go build ./...` confirms everything compiles
+
 ## Special Thanks
 
 - <https://github.com/wi1dcard/v2ray-exporter>


### PR DESCRIPTION
Small follow-up to #19. Adds a **Development** section documenting a single command to format, vet, and build before committing — mirrors the CI lint gate added in #19:

```bash
gofmt -w . && go vet ./... && go build ./...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)