### PR TITLE
ci: adopt new action features (SBOM, provenance, annotations, guards)

### DIFF
--- a/.github/workflows/build-release-deploy.yml
+++ b/.github/workflows/build-release-deploy.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -60,7 +62,9 @@ jobs:
             goarch: arm64
     steps:
     - uses: actions/checkout@v7
-    
+      with:
+        persist-credentials: false
+
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
@@ -95,6 +99,7 @@ jobs:
         name: xray-exporter-${{ matrix.goos }}-${{ matrix.goarch }}
         path: dist/
         retention-days: 7
+        if-no-files-found: error
 
   docker:
     if: github.event_name != 'pull_request'
@@ -105,7 +110,9 @@ jobs:
       packages: write
     steps:
     - uses: actions/checkout@v7
-    
+      with:
+        persist-credentials: false
+
     - name: Download all artifacts
       uses: actions/download-artifact@v7
       with:
@@ -122,16 +129,29 @@ jobs:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        
+
+    - name: Extract image metadata
+      id: meta
+      uses: docker/metadata-action@v6
+      env:
+        DOCKER_METADATA_ANNOTATIONS_LEVELS: index
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=tag
+          type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+
     - name: Build and push multi-arch image
       uses: docker/build-push-action@v7
       with:
         context: .
         platforms: linux/amd64,linux/arm64,linux/arm/v7
         push: true
-        tags: |
-          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-          ${{ startsWith(github.ref, 'refs/tags/') && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        annotations: ${{ steps.meta.outputs.annotations }}
+        provenance: mode=max
+        sbom: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
 


### PR DESCRIPTION
Adopts opt-in features unlocked by the recent Dependabot action bumps.

## Changes
- **`docker/build-push-action`**: `sbom: true` + `provenance: mode=max` — attach SBOM and SLSA provenance attestations to the ghcr.io image.
- **`docker/build-push-action`**: OCI `annotations` via new `docker/metadata-action@v6` step (`DOCKER_METADATA_ANNOTATIONS_LEVELS: index`), replacing the hand-rolled inline tag logic. **Tag behavior is preserved**: branch push → `:<branch>`, tag push → `:<tag>` + `:latest`.
- **`actions/upload-artifact`**: `if-no-files-found: error` — fail loudly if a build produces no binary instead of shipping an incomplete release.
- **`actions/checkout`** (all 3 jobs): `persist-credentials: false` — no job runs authenticated git after checkout.

## Notes
- The `docker` job only runs on push/tag, so these steps first execute on the next merge to `main`, not in PR CI.
- New dependency `docker/metadata-action@v6` is covered by existing Dependabot github-actions config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)