### PR TITLE
ci: expand Dependabot to cover Go modules and Docker base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,22 @@
-
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Dependabot previously watched only `github-actions`, leaving two ecosystems unmonitored.

## Changes
- **`gomod`** — now watches `go.mod`/`go.sum` (grpc, xray-core, prometheus, geoip2, logrus, golang.org/x/*). This was the significant gap for a network-facing service.
- **`docker`** — now watches the `alpine` base image in the Dockerfile for patch/major bumps.
- **grouping** — `github-actions` and `go-deps` bumps are grouped into single PRs to reduce review noise.

Weekly cadence and `directory: "/"` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)