### PR TITLE
fix: parse log timestamps in local time

### DIFF
--- a/internal/logparser/parser.go
+++ b/internal/logparser/parser.go
@@ -633,7 +633,9 @@ func (p *Parser) parseLine(line string) (*LogEntry, error) {
 		return nil, nil // Skip lines without timestamp
 	}
 
-	timestamp, err := time.Parse("2006/01/02 15:04:05", timestampMatch[1])
+	// Xray writes local time, so parse in the local zone. Parsing as UTC would
+	// shift every timestamp by the UTC offset and break the time-window filter.
+	timestamp, err := time.ParseInLocation("2006/01/02 15:04:05", timestampMatch[1], time.Local)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Xray writes access log timestamps in local time, but the parser used `time.Parse`, which interprets them as UTC. On any server not running UTC, every parsed timestamp is shifted by the UTC offset, which breaks the time-window filter behind `unique_users` and `total_connections`:

- East of UTC: entries appear to be in the future, so IPs never expire within the window and `unique_users` is inflated (window + offset).
- West of UTC: entries appear old and can expire immediately, driving the count toward zero.

Fix: parse with `time.ParseInLocation(..., time.Local)` to match how Xray writes the log.

Verified: `go build ./...` and `go vet ./...` clean. No tests exist for the parser, so none run against this change.