### PR TITLE
fix: correct metric types and drop misleading _total suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,11 +286,13 @@ To learn more about Prometheus, please visit the [official docs](https://prometh
 | :----- | :---------- | :----- |
 | `xray_unique_users` | Number of unique users active in the time window | - |
 | `xray_total_connections` | Total number of connections in the time window | - |
-| `xray_requested_domain_ip_total` | Total requests per domain or IP address | `target` |
-| `xray_outbound_requests_total` | Total requests per outbound connection | `outbound` |
-| `xray_asns_total` | Total requests per ASN | `asn`, `org` |
-| `xray_countries_total` | Total requests per country | `country` |
-| `xray_cities_total` | Total requests per city | `city`, `country` |
+| `xray_requested_domain_ip` | Requests per domain or IP address (top-N in time window) | `target` |
+| `xray_outbound_requests` | Requests per outbound connection (top-N in time window) | `outbound` |
+| `xray_asns` | Requests per ASN (top-N in time window) | `asn`, `org` |
+| `xray_countries` | Requests per country (top-N in time window) | `country` |
+| `xray_cities` | Requests per city (top-N in time window) | `city`, `country` |
+
+> These are gauges, not counters. They hold current top-N request counts in the time window and are trimmed each scrape, so the value is not monotonic. Do not apply `rate()`/`increase()`.
 
 ### Core Metrics
 
@@ -306,9 +308,9 @@ Use these queries to visualize the new GeoIP metrics:
 
 These series are gauges (top-N request counts since the parser started, periodically trimmed), so query the value directly rather than with `rate()`/`increase()`:
 
-- **Top 10 ASNs**: `topk(10, sum by (asn, org) (xray_asns_total))`
-- **Top 10 Countries**: `topk(10, sum by (country) (xray_countries_total))`
-- **Top 10 Cities**: `topk(10, sum by (city, country) (xray_cities_total))`
+- **Top 10 ASNs**: `topk(10, sum by (asn, org) (xray_asns))`
+- **Top 10 Countries**: `topk(10, sum by (country) (xray_countries))`
+- **Top 10 Cities**: `topk(10, sum by (city, country) (xray_cities))`
 
 ## Performance & Scalability
 

--- a/exporter.go
+++ b/exporter.go
@@ -80,19 +80,39 @@ func NewExporterWithLogConfig(endpoint string, scrapeTimeout time.Duration, user
 		"traffic_uplink_bytes_total":   {txt: "Number of transmitted bytes", lbls: []string{"dimension", "target"}},
 		"traffic_downlink_bytes_total": {txt: "Number of received bytes", lbls: []string{"dimension", "target"}},
 
-		// User activity metrics from log parsing
+		// Xray runtime metrics from GetSysStats
+		"goroutines":                 {txt: "Number of goroutines running in the Xray process"},
+		"memstats_alloc_bytes":       {txt: "Bytes of allocated heap objects"},
+		"memstats_alloc_bytes_total": {txt: "Cumulative bytes allocated for heap objects"},
+		"memstats_sys_bytes":         {txt: "Total bytes of memory obtained from the OS"},
+		"memstats_mallocs_total":     {txt: "Cumulative count of heap objects allocated"},
+		"memstats_frees_total":       {txt: "Cumulative count of heap objects freed"},
+		"memstats_num_gc":            {txt: "Number of completed GC cycles"},
+		"memstats_pause_total_ns":    {txt: "Cumulative nanoseconds in GC stop-the-world pauses"},
+
+		// User activity metrics from log parsing.
+		// The per-target counts below are gauges: they are trimmed to top-N each
+		// scrape, so the value is not monotonic and must not carry a _total suffix.
 		"unique_users":      {txt: "Number of unique users in time window"},
 		"total_connections": {txt: "Total number of connections in time window"},
-		"asns_total": {
-			txt:  "Total number of requests per ASN",
+		"requested_domain_ip": {
+			txt:  "Number of requests per domain or IP (top-N in time window)",
+			lbls: []string{"target"},
+		},
+		"outbound_requests": {
+			txt:  "Number of requests per outbound (top-N in time window)",
+			lbls: []string{"outbound"},
+		},
+		"asns": {
+			txt:  "Number of requests per ASN (top-N in time window)",
 			lbls: []string{"asn", "org"},
 		},
-		"countries_total": {
-			txt:  "Total number of requests per country",
+		"countries": {
+			txt:  "Number of requests per country (top-N in time window)",
 			lbls: []string{"country"},
 		},
-		"cities_total": {
-			txt:  "Total number of requests per city",
+		"cities": {
+			txt:  "Number of requests per city (top-N in time window)",
 			lbls: []string{"city", "country"},
 		},
 	} {
@@ -205,13 +225,6 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	}
 
 	ch <- e.totalScrapes.Desc()
-
-	ch <- prometheus.NewDesc(
-		prometheus.BuildFQName("xray", "", "requested_domain_ip_total"),
-		"Total number of requests per domain or IP",
-		[]string{"target"},
-		nil,
-	)
 }
 
 // Connects to Xray's gRPC API and collects all available metrics.
@@ -282,17 +295,18 @@ func (e *Exporter) scrapeXraySysMetrics(ctx context.Context, ch chan<- prometheu
 	sysResp := resp.(*command.SysStatsResponse)
 	e.registerConstMetricGauge(ch, "uptime_seconds", float64(sysResp.GetUptime()))
 
-	// Memory and runtime metrics following Go collector naming conventions
+	// Memory and runtime metrics following Go collector naming conventions.
+	// Current-value readings are gauges; cumulative counts carry _total and are counters.
 	e.registerConstMetricGauge(ch, "goroutines", float64(sysResp.GetNumGoroutine()))
 	e.registerConstMetricGauge(ch, "memstats_alloc_bytes", float64(sysResp.GetAlloc()))
-	e.registerConstMetricGauge(ch, "memstats_alloc_bytes_total", float64(sysResp.GetTotalAlloc()))
+	e.registerConstMetricCounter(ch, "memstats_alloc_bytes_total", float64(sysResp.GetTotalAlloc()))
 	e.registerConstMetricGauge(ch, "memstats_sys_bytes", float64(sysResp.GetSys()))
-	e.registerConstMetricGauge(ch, "memstats_mallocs_total", float64(sysResp.GetMallocs()))
-	e.registerConstMetricGauge(ch, "memstats_frees_total", float64(sysResp.GetFrees()))
+	e.registerConstMetricCounter(ch, "memstats_mallocs_total", float64(sysResp.GetMallocs()))
+	e.registerConstMetricCounter(ch, "memstats_frees_total", float64(sysResp.GetFrees()))
 
 	// Additional memory metrics not in standard Go collector
-	e.registerConstMetricGauge(ch, "memstats_num_gc", float64(sysResp.GetNumGC()))
-	e.registerConstMetricGauge(ch, "memstats_pause_total_ns", float64(sysResp.GetPauseTotalNs()))
+	e.registerConstMetricCounter(ch, "memstats_num_gc", float64(sysResp.GetNumGC()))
+	e.registerConstMetricCounter(ch, "memstats_pause_total_ns", float64(sysResp.GetPauseTotalNs()))
 
 	return nil
 }
@@ -389,12 +403,7 @@ func (e *Exporter) collectDomainMetrics(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	metricDesc := prometheus.NewDesc(
-		prometheus.BuildFQName("xray", "", "requested_domain_ip_total"),
-		"Total number of requests per domain or IP",
-		[]string{"target"},
-		nil,
-	)
+	metricDesc := e.metricDescriptions["requested_domain_ip"]
 
 	// Only export the top domains and IPs to prevent cardinality leak.
 	// These are gauges: the backing counts are periodically trimmed to the
@@ -413,12 +422,7 @@ func (e *Exporter) collectOutboundMetrics(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	metricDesc := prometheus.NewDesc(
-		prometheus.BuildFQName("xray", "", "outbound_requests_total"),
-		"Total number of requests per outbound",
-		[]string{"outbound"},
-		nil,
-	)
+	metricDesc := e.metricDescriptions["outbound_requests"]
 
 	// Only export the top outbounds to prevent cardinality leak (gauge, see note above).
 	for _, entry := range topN(e.logParser.GetOutboundCounts(), logparser.MaxTrackedOutbounds) {
@@ -440,7 +444,7 @@ func (e *Exporter) collectASNMetrics(ch chan<- prometheus.Metric) {
 		if len(parts) > 1 {
 			org = parts[1]
 		}
-		e.registerConstMetricGauge(ch, "asns_total", float64(entry.count), asn, org)
+		e.registerConstMetricGauge(ch, "asns", float64(entry.count), asn, org)
 	}
 }
 
@@ -451,7 +455,7 @@ func (e *Exporter) collectCountryMetrics(ch chan<- prometheus.Metric) {
 	}
 
 	for _, entry := range topN(e.logParser.GetCountryCounts(), logparser.MaxTrackedCountries) {
-		e.registerConstMetricGauge(ch, "countries_total", float64(entry.count), entry.key)
+		e.registerConstMetricGauge(ch, "countries", float64(entry.count), entry.key)
 	}
 }
 
@@ -469,7 +473,7 @@ func (e *Exporter) collectCityMetrics(ch chan<- prometheus.Metric) {
 		if len(parts) > 1 {
 			country = parts[1]
 		}
-		e.registerConstMetricGauge(ch, "cities_total", float64(entry.count), city, country)
+		e.registerConstMetricGauge(ch, "cities", float64(entry.count), city, country)
 	}
 }
 


### PR DESCRIPTION
## What

Cleans up the metric layer. Two kinds of change:

**Breaking rename** — five gauges wrongly carried a `_total` suffix. They hold top-N request counts that get trimmed each scrape, so the value is not monotonic and `rate()`/`increase()` on them was meaningless. Dropped the suffix:

| Old | New |
| --- | --- |
| `xray_requested_domain_ip_total` | `xray_requested_domain_ip` |
| `xray_outbound_requests_total` | `xray_outbound_requests` |
| `xray_asns_total` | `xray_asns` |
| `xray_countries_total` | `xray_countries` |
| `xray_cities_total` | `xray_cities` |

**Non-breaking** — runtime metrics from `GetSysStats` now have real HELP text instead of auto-generated placeholders, and the cumulative ones (`memstats_alloc_bytes_total`, `memstats_mallocs_total`, `memstats_frees_total`, `memstats_num_gc`, `memstats_pause_total_ns`) emit as counters instead of gauges. Names unchanged.

Also: domain/outbound descriptors are built once in the constructor and reused instead of re-allocated every scrape, and every metric is now declared in one place.

## Blast radius

The rename blanks out any Grafana panel or alert querying the five old names once deployed. Dashboards and alert rules need updating to the new names in the same window. The type/help changes are invisible to Grafana (series names unchanged).

README metric tables and example queries updated.

## Verification

- `go build ./...` — pass
- `go vet ./...` — pass
- `gofmt` — clean
- `go test ./...` — pass, but the repo has no test files, so nothing exercises these changes
- `golangci-lint` / `-race` not run: linter not installed and no C compiler in this environment