### PR TITLE
improve logging: info default, throttled warnings, json format

### DIFF
--- a/internal/logparser/parser.go
+++ b/internal/logparser/parser.go
@@ -479,13 +479,23 @@ func (p *Parser) parseLoop() {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
+	// Track the last parse error so a persistent failure (missing file, bad
+	// permissions) is logged once on change rather than every 5s tick.
+	var lastErrMsg string
+
 	for {
 		select {
 		case <-p.ctx.Done():
 			return
 		case <-ticker.C:
 			if err := p.parseLogFile(); err != nil {
-				logrus.WithError(err).Warn("Failed to parse log file")
+				if msg := err.Error(); msg != lastErrMsg {
+					logrus.WithError(err).Warn("Failed to parse log file")
+					lastErrMsg = msg
+				}
+			} else if lastErrMsg != "" {
+				logrus.Info("Log file parsing recovered")
+				lastErrMsg = ""
 			}
 			cutoff := time.Now().Add(-p.timeWindow)
 			p.expireWindowed(cutoff)

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ var opts struct {
 	LogTimeWindowMinutes   int    `short:"w" long:"log-time-window" description:"Time window in minutes for user metrics" value-name:"N"`
 	GeoIPDir               string `short:"g" long:"geoip-dir" description:"Directory for GeoLite2 databases" value-name:"PATH" default:"."`
 	Version                bool   `long:"version" description:"Display the version and exit"`
-	LogLevel               string `long:"log-level" description:"Log level: error, warn, info, debug (env: LOG_LEVEL) (default: warn)" value-name:"LEVEL"`
+	LogLevel               string `long:"log-level" description:"Log level: error, warn, info, debug (env: LOG_LEVEL) (default: info)" value-name:"LEVEL"`
 }
 
 // Build information injected during compilation
@@ -56,8 +56,8 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // configureLogging sets the global logrus level. Precedence: the --log-level
-// flag, then the LOG_LEVEL env var, then "warn". Only error, warn, info, and
-// debug are accepted; anything else is non-fatal and falls back to warn, so a
+// flag, then the LOG_LEVEL env var, then "info". Only error, warn, info, and
+// debug are accepted; anything else is non-fatal and falls back to info, so a
 // typo never stops startup.
 func configureLogging(flagLevel string) {
 	levelStr := flagLevel
@@ -65,7 +65,7 @@ func configureLogging(flagLevel string) {
 		levelStr = os.Getenv("LOG_LEVEL")
 	}
 	if levelStr == "" {
-		levelStr = "warn"
+		levelStr = "info"
 	}
 
 	var level logrus.Level
@@ -79,8 +79,8 @@ func configureLogging(flagLevel string) {
 	case "debug":
 		level = logrus.DebugLevel
 	default:
-		logrus.Warnf("invalid log level %q, defaulting to warn", levelStr)
-		level = logrus.WarnLevel
+		logrus.Warnf("invalid log level %q, defaulting to info", levelStr)
+		level = logrus.InfoLevel
 	}
 	logrus.SetLevel(level)
 }
@@ -96,8 +96,8 @@ func main() {
 
 	configureLogging(opts.LogLevel)
 
-	// Print the identity banner directly so it is never hidden by the log level
-	// (the default is warn, which would otherwise suppress this and --version).
+	// Print the identity banner directly so it is never hidden regardless of the
+	// configured log level (e.g. --log-level error), which also covers --version.
 	fmt.Printf("Xray Exporter %v-%v (built %v)\n", buildVersion, buildCommit, buildDate)
 
 	if opts.Version {

--- a/main.go
+++ b/main.go
@@ -53,7 +53,9 @@ func scrapeHandler(exporter *Exporter) http.HandlerFunc {
 // Simple health check endpoint
 func healthHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("OK"))
+	if _, err := w.Write([]byte("OK")); err != nil {
+		logrus.WithError(err).Debug("Failed to write health check response")
+	}
 }
 
 // firstNonEmpty returns the first non-empty string, or "" if all are empty.

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var opts struct {
 	GeoIPDir               string `short:"g" long:"geoip-dir" description:"Directory for GeoLite2 databases" value-name:"PATH" default:"."`
 	Version                bool   `long:"version" description:"Display the version and exit"`
 	LogLevel               string `long:"log-level" description:"Log level: error, warn, info, debug (env: LOG_LEVEL) (default: info)" value-name:"LEVEL"`
+	LogFormat              string `long:"log-format" description:"Log format: text, json (env: LOG_FORMAT) (default: text)" value-name:"FORMAT"`
 }
 
 // Build information injected during compilation
@@ -55,19 +56,22 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("OK"))
 }
 
-// configureLogging sets the global logrus level. Precedence: the --log-level
-// flag, then the LOG_LEVEL env var, then "info". Only error, warn, info, and
-// debug are accepted; anything else is non-fatal and falls back to info, so a
-// typo never stops startup.
-func configureLogging(flagLevel string) {
-	levelStr := flagLevel
-	if levelStr == "" {
-		levelStr = os.Getenv("LOG_LEVEL")
+// firstNonEmpty returns the first non-empty string, or "" if all are empty.
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
 	}
-	if levelStr == "" {
-		levelStr = "info"
-	}
+	return ""
+}
 
+// configureLogging sets the global logrus level and output format. For each,
+// precedence is the flag, then the env var, then the default (info level, text
+// format). Unrecognized values are non-fatal and fall back to the default, so a
+// typo never stops startup.
+func configureLogging(flagLevel, flagFormat string) {
+	levelStr := firstNonEmpty(flagLevel, os.Getenv("LOG_LEVEL"), "info")
 	var level logrus.Level
 	switch strings.ToLower(levelStr) {
 	case "error":
@@ -83,6 +87,17 @@ func configureLogging(flagLevel string) {
 		level = logrus.InfoLevel
 	}
 	logrus.SetLevel(level)
+
+	formatStr := firstNonEmpty(flagFormat, os.Getenv("LOG_FORMAT"), "text")
+	switch strings.ToLower(formatStr) {
+	case "text":
+		logrus.SetFormatter(&logrus.TextFormatter{})
+	case "json":
+		logrus.SetFormatter(&logrus.JSONFormatter{})
+	default:
+		logrus.Warnf("invalid log format %q, defaulting to text", formatStr)
+		logrus.SetFormatter(&logrus.TextFormatter{})
+	}
 }
 
 func main() {
@@ -94,7 +109,7 @@ func main() {
 		logrus.WithError(err).Fatal("Failed to parse flags")
 	}
 
-	configureLogging(opts.LogLevel)
+	configureLogging(opts.LogLevel, opts.LogFormat)
 
 	// Print the identity banner directly so it is never hidden regardless of the
 	// configured log level (e.g. --log-level error), which also covers --version.


### PR DESCRIPTION
Cleanup of the exporter's own logging (logrus), not the log-parsing pipeline.

**Default level `warn` -> `info`.** `warn` hid every startup and operational line (server start, log-parser attach, geoip progress), so operators saw only the banner. `info` is the usual exporter default; drop to `warn`/`error` to quiet it.

**Throttle repeated parse-failure warnings.** A persistently unreadable log file (missing, bad perms) logged the same warning every 5s forever. Now it logs once when the error changes and logs recovery when it clears.

**Add `--log-format` (text/json).** `LOG_FORMAT=json` makes logs parseable by aggregators (Loki/ELK). Defaults to text, no behavior change unless opted in.

**Log health-check write errors at debug.** Stops discarding the `ResponseWriter` error (errcheck); debug keeps it silent in normal operation.

## Verification
- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` — no test files in the repo
- `-race` not run here (no cgo/gcc in this env); golangci-lint not installed locally. Both left to CI.
