### PR TITLE
docs: clean up code comments

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -1,4 +1,3 @@
-// Core exporter functionality for collecting Xray metrics.
 package main
 
 import (
@@ -22,7 +21,6 @@ import (
 	"xray-exporter/internal/logparser"
 )
 
-// Default time window for user activity metrics (in minutes)
 const DefaultLogTimeWindowMinutes = 5
 
 // Collects Xray metrics and exposes them in Prometheus format.
@@ -37,12 +35,12 @@ type Exporter struct {
 	metricDescriptions map[string]*prometheus.Desc
 	conn               *grpc.ClientConn
 
-	// Log parsing for user metrics
+	// Log parsing for user metrics.
 	logParser     *logparser.Parser
 	logPath       string
 	logTimeWindow time.Duration
 
-	// GeoIP for ASN lookups
+	// GeoIP readers for log enrichment.
 	geoipASNReader     *geoip2.Reader
 	geoipCityReader    *geoip2.Reader
 	geoipCountryReader *geoip2.Reader
@@ -66,21 +64,20 @@ func NewExporterWithLogConfig(endpoint string, scrapeTimeout time.Duration, user
 		}),
 	}
 
-	// Initialize all metric descriptions
 	e.metricDescriptions = map[string]*prometheus.Desc{}
 
 	for k, desc := range map[string]struct {
 		txt  string
 		lbls []string
 	}{
-		// Core Xray metrics
+		// Core Xray metrics.
 		"up":                           {txt: "Indicate scrape succeeded or not"},
 		"scrape_duration_seconds":      {txt: "Scrape duration in seconds"},
 		"uptime_seconds":               {txt: "Xray uptime in seconds"},
 		"traffic_uplink_bytes_total":   {txt: "Number of transmitted bytes", lbls: []string{"dimension", "target"}},
 		"traffic_downlink_bytes_total": {txt: "Number of received bytes", lbls: []string{"dimension", "target"}},
 
-		// Xray runtime metrics from GetSysStats
+		// Xray runtime metrics from GetSysStats.
 		"goroutines":                 {txt: "Number of goroutines running in the Xray process"},
 		"memstats_alloc_bytes":       {txt: "Bytes of allocated heap objects"},
 		"memstats_alloc_bytes_total": {txt: "Cumulative bytes allocated for heap objects"},
@@ -122,8 +119,7 @@ func NewExporterWithLogConfig(endpoint string, scrapeTimeout time.Duration, user
 
 	e.registry.MustRegister(&e)
 
-	// Create simple gRPC connection
-	// No keepalive needed for short, infrequent calls every 15-30s
+	// No keepalive: calls are short and infrequent (one per 15-30s scrape).
 	conn, err := grpc.NewClient(endpoint,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
@@ -142,7 +138,6 @@ func NewExporterWithLogConfig(endpoint string, scrapeTimeout time.Duration, user
 	}
 
 	if cityDB, err := geoip2.Open(geoip.CityPath()); err != nil {
-		// If city database is missing, we still continue but city/country metrics will be unknown
 		logrus.WithError(err).Warn("Failed to open GeoIP City database, city/country metrics will be unavailable")
 	} else {
 		e.geoipCityReader = cityDB
@@ -154,7 +149,6 @@ func NewExporterWithLogConfig(endpoint string, scrapeTimeout time.Duration, user
 		e.geoipCountryReader = countryDB
 	}
 
-	// Initialize log parser if path provided
 	if logPath != "" && logPath != "disabled" {
 		if _, err := os.Stat(logPath); err != nil {
 			logrus.WithError(err).Warn("Log file not found, user metrics will not be available")
@@ -197,14 +191,12 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.totalScrapes.Inc()
 	start := time.Now()
 
-	// Attempt to scrape Xray metrics via gRPC
 	var up float64 = 1
 	if err := e.scrapeXray(ch); err != nil {
 		up = 0
 		logrus.WithError(err).Warn("Scrape failed")
 	}
 
-	// Collect log-based metrics
 	e.collectLogMetrics(ch)
 	e.collectDomainMetrics(ch)
 	e.collectOutboundMetrics(ch)
@@ -212,7 +204,6 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.collectCountryMetrics(ch)
 	e.collectCityMetrics(ch)
 
-	// Core metrics
 	e.registerConstMetricGauge(ch, "up", up)
 	e.registerConstMetricGauge(ch, "scrape_duration_seconds", time.Since(start).Seconds())
 
@@ -257,11 +248,10 @@ func (e *Exporter) scrapeXrayMetrics(ctx context.Context, ch chan<- prometheus.M
 
 	statsResp := resp.(*command.QueryStatsResponse)
 	for _, s := range statsResp.GetStat() {
-		// Parse format: inbound>>>socks-proxy>>>traffic>>>uplink
+		// Stat name format: inbound>>>socks-proxy>>>traffic>>>uplink.
 		p := strings.Split(s.GetName(), ">>>")
 
-		// Skip names that don't match the expected 4-part format to avoid
-		// index-out-of-range panics on custom/unexpected stat names.
+		// Custom or unexpected stat names may not have all 4 parts.
 		if len(p) < 4 {
 			logrus.Debugf("skipping unexpected stat name %q", s.GetName())
 			continue
@@ -305,7 +295,7 @@ func (e *Exporter) scrapeXraySysMetrics(ctx context.Context, ch chan<- prometheu
 	e.registerConstMetricCounter(ch, "memstats_mallocs_total", float64(sysResp.GetMallocs()))
 	e.registerConstMetricCounter(ch, "memstats_frees_total", float64(sysResp.GetFrees()))
 
-	// Additional memory metrics not in standard Go collector
+	// Additional memory metrics not in the standard Go collector.
 	e.registerConstMetricCounter(ch, "memstats_num_gc", float64(sysResp.GetNumGC()))
 	e.registerConstMetricCounter(ch, "memstats_pause_total_ns", float64(sysResp.GetPauseTotalNs()))
 
@@ -425,7 +415,7 @@ func (e *Exporter) collectOutboundMetrics(ch chan<- prometheus.Metric) {
 
 	metricDesc := e.metricDescriptions["outbound_requests"]
 
-	// Only export the top outbounds to prevent cardinality leak (gauge, see note above).
+	// Top-N only, to bound cardinality (gauge, see note in collectDomainMetrics).
 	for _, entry := range topN(e.logParser.GetOutboundCounts(), logparser.MaxTrackedOutbounds) {
 		ch <- prometheus.MustNewConstMetric(metricDesc, prometheus.GaugeValue, float64(entry.count), entry.key)
 	}
@@ -438,7 +428,7 @@ func (e *Exporter) collectASNMetrics(ch chan<- prometheus.Metric) {
 	}
 
 	for _, entry := range topN(e.logParser.GetASNCounts(), logparser.MaxTrackedASNs) {
-		// Key format: asn|org
+		// Key format: asn|org.
 		parts := strings.Split(entry.key, "|")
 		asn := parts[0]
 		org := ""
@@ -467,7 +457,7 @@ func (e *Exporter) collectCityMetrics(ch chan<- prometheus.Metric) {
 	}
 
 	for _, entry := range topN(e.logParser.GetCityCounts(), logparser.MaxTrackedCities) {
-		// Key format: city|country
+		// Key format: city|country.
 		parts := strings.Split(entry.key, "|")
 		city := parts[0]
 		country := ""
@@ -478,7 +468,7 @@ func (e *Exporter) collectCityMetrics(ch chan<- prometheus.Metric) {
 	}
 }
 
-// Properly closes gRPC connection and stops log parser.
+// Closes the gRPC connection, GeoIP readers, and log parser.
 func (e *Exporter) Close() error {
 	if e.logParser != nil {
 		e.logParser.Stop()

--- a/internal/geoip/downloader.go
+++ b/internal/geoip/downloader.go
@@ -21,32 +21,29 @@ const (
 	cityFile    = "GeoLite2-City.mmdb"
 	countryFile = "GeoLite2-Country.mmdb"
 
-	// userAgent identifies this client to the upstream host.
+	// Identifies this client to the upstream host.
 	userAgent = "xray-exporter (+https://github.com/compassvpn/xray-exporter)"
 
-	// dbMaxAge is how long an existing database is considered fresh enough to
-	// skip re-downloading on startup.
+	// How long an existing database is considered fresh enough to skip
+	// re-downloading on startup.
 	dbMaxAge = 7 * 24 * time.Hour
 
-	// downloadTimeout bounds a single download attempt.
+	// Bounds a single download attempt.
 	downloadTimeout = 60 * time.Second
 )
 
-// Dir is the directory where GeoLite2 databases are stored and read from.
+// Directory where GeoLite2 databases are stored and read from.
 // Override it (e.g. from a --geoip-dir flag) before calling DownloadDB.
 var Dir = "."
 
-// ASNPath returns the path to the GeoLite2 ASN database.
 func ASNPath() string { return filepath.Join(Dir, asnFile) }
 
-// CityPath returns the path to the GeoLite2 City database.
 func CityPath() string { return filepath.Join(Dir, cityFile) }
 
-// CountryPath returns the path to the GeoLite2 Country database.
 func CountryPath() string { return filepath.Join(Dir, countryFile) }
 
-// DownloadDB downloads the latest GeoLite2 databases with retries, skipping any
-// that already exist locally and are recent enough.
+// Downloads the latest GeoLite2 databases with retries, skipping any that
+// already exist locally and are recent enough.
 func DownloadDB() error {
 	if err := os.MkdirAll(Dir, 0o755); err != nil {
 		return fmt.Errorf("failed to create GeoIP directory %q: %w", Dir, err)
@@ -74,7 +71,7 @@ func DownloadDB() error {
 	return nil
 }
 
-// isFresh reports whether path exists, is non-empty, and was modified within dbMaxAge.
+// Reports whether path exists, is non-empty, and was modified within dbMaxAge.
 func isFresh(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -102,8 +99,8 @@ func downloadWithRetry(client *http.Client, name, url, path string) error {
 	return fmt.Errorf("failed to download GeoLite2-%s database after %d attempts: %w", name, maxRetries, lastErr)
 }
 
-// downloadFile streams url to a temp file in the same directory and atomically
-// renames it into place, so a failed download never corrupts an existing DB.
+// Streams url to a temp file in the same directory and atomically renames it
+// into place, so a failed download never corrupts an existing DB.
 func downloadFile(client *http.Client, path, url string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
 	defer cancel()

--- a/internal/logparser/filter.go
+++ b/internal/logparser/filter.go
@@ -1,5 +1,3 @@
-// IP filtering functionality to exclude system and internal traffic
-// from user metrics. Helps focus on real user activity rather than infrastructure noise.
 package logparser
 
 import (
@@ -12,14 +10,14 @@ import (
 // Uses multiple strategies: exact matches for system IPs, network ranges for private IPs,
 // and an LRU cache (O(1) eviction) to avoid repeated expensive lookups.
 type IPFilter struct {
-	systemIPs   map[string]bool // Known system/localhost addresses
-	dnsServers  map[string]bool // Common public DNS servers
-	privateNets []*net.IPNet    // Private network ranges (RFC 1918, etc.)
+	systemIPs   map[string]bool // known system/localhost addresses.
+	dnsServers  map[string]bool // common public DNS servers.
+	privateNets []*net.IPNet    // private network ranges (RFC 1918, etc.).
 
-	mu           sync.Mutex               // Protects the LRU cache
-	cache        map[string]*list.Element // ip -> element in lru
-	lru          *list.List               // most-recently-used at the front
-	maxCacheSize int                      // Maximum cache entries before eviction
+	mu           sync.Mutex               // protects the LRU cache.
+	cache        map[string]*list.Element // ip -> element in lru.
+	lru          *list.List               // most-recently-used at the front.
+	maxCacheSize int                      // maximum cache entries before eviction.
 }
 
 // Stores a cached filter result for one IP.
@@ -39,7 +37,6 @@ func NewIPFilter() *IPFilter {
 		maxCacheSize: 100000,
 	}
 
-	// System and localhost addresses
 	systemIPs := []string{
 		"127.0.0.1",
 		"localhost",
@@ -49,7 +46,7 @@ func NewIPFilter() *IPFilter {
 		filter.systemIPs[ip] = true
 	}
 
-	// Common public DNS servers - these generate noise in proxy logs
+	// Common public DNS servers; these generate noise in proxy logs.
 	dnsServers := []string{
 		// Cloudflare DNS
 		"1.1.1.1", "1.0.0.1", "1.1.1.2", "1.0.0.2", "1.1.1.3", "1.0.0.3",
@@ -76,13 +73,13 @@ func NewIPFilter() *IPFilter {
 		filter.dnsServers[ip] = true
 	}
 
-	// Private network ranges (RFC 1918 and IPv6 equivalents)
+	// Private network ranges (RFC 1918 and IPv6 equivalents).
 	privateNetworks := []string{
-		"10.0.0.0/8",     // Class A private networks
-		"172.16.0.0/12",  // Class B private networks
-		"192.168.0.0/16", // Class C private networks
-		"fc00::/7",       // IPv6 unique local addresses
-		"fe80::/10",      // IPv6 link-local addresses
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"fc00::/7",  // IPv6 unique local addresses.
+		"fe80::/10", // IPv6 link-local addresses.
 	}
 
 	for _, cidr := range privateNetworks {
@@ -130,10 +127,9 @@ func (f *IPFilter) ShouldFilter(ip string) bool {
 	return result
 }
 
-// Performs the actual filtering logic without caching.
-// Checks system IPs, DNS servers, and private network ranges in order of efficiency.
+// Performs the actual filtering logic without caching: system IPs, DNS
+// servers, then private network ranges.
 func (f *IPFilter) shouldFilterInternal(ip string) bool {
-	// Check exact matches first (fastest)
 	if f.systemIPs[ip] {
 		return true
 	}
@@ -142,19 +138,16 @@ func (f *IPFilter) shouldFilterInternal(ip string) bool {
 		return true
 	}
 
-	// Parse IP for network range checks
 	parsedIP := net.ParseIP(ip)
 	if parsedIP == nil {
-		return true // Filter invalid IPs
+		return true // Filter invalid IPs.
 	}
 
-	// Check if IP falls within private network ranges
 	for _, ipNet := range f.privateNets {
 		if ipNet.Contains(parsedIP) {
 			return true
 		}
 	}
 
-	// IP is not filtered - it's a real user
 	return false
 }

--- a/internal/logparser/inode_unix.go
+++ b/internal/logparser/inode_unix.go
@@ -1,7 +1,5 @@
 //go:build unix
 
-// Cross-platform file tracking functionality.
-// This Unix implementation uses actual inode numbers for reliable log rotation detection.
 package logparser
 
 import (
@@ -9,8 +7,7 @@ import (
 	"syscall"
 )
 
-// Returns the inode number of a file on Unix systems.
-// Inodes are unique identifiers that help detect when log files are rotated or replaced.
+// Returns the inode number of a file, used to detect log rotation.
 // Returns 0 if the inode cannot be determined (rare on Unix systems).
 func getInode(_ *os.File, fileInfo os.FileInfo) uint64 {
 	if stat, ok := fileInfo.Sys().(*syscall.Stat_t); ok {

--- a/internal/logparser/inode_windows.go
+++ b/internal/logparser/inode_windows.go
@@ -1,9 +1,5 @@
 //go:build windows
 
-// Cross-platform file tracking functionality.
-// This Windows implementation uses the NTFS file index (a stable per-file id,
-// the closest equivalent to a Unix inode) so that appending to a log file is
-// NOT mistaken for a rotation. ModTime is only used as a last-resort fallback.
 package logparser
 
 import (
@@ -12,10 +8,10 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// Returns a stable file identifier for Windows systems.
-// It reads the NTFS file index via GetFileInformationByHandle, which (unlike
-// ModTime) does not change when the file is appended to, so an actively-written
-// log is not repeatedly re-read from the start.
+// Returns a stable per-file id (the closest Windows equivalent to a Unix
+// inode), used to detect log rotation. It reads the NTFS file index via
+// GetFileInformationByHandle, which (unlike ModTime) does not change on
+// append, so an actively-written log is not repeatedly re-read from the start.
 func getInode(file *os.File, fileInfo os.FileInfo) uint64 {
 	var info windows.ByHandleFileInformation
 	if err := windows.GetFileInformationByHandle(windows.Handle(file.Fd()), &info); err == nil {

--- a/internal/logparser/parser.go
+++ b/internal/logparser/parser.go
@@ -1,6 +1,5 @@
-// Parses Xray access logs and extracts user metrics.
-// Monitors log files for changes and maintains real-time statistics about user activity,
-// domain requests, and connection patterns.
+// Parses Xray access logs and extracts user metrics: user activity, domain
+// requests, and connection patterns within a rolling time window.
 package logparser
 
 import (
@@ -21,17 +20,17 @@ import (
 	"golang.org/x/net/publicsuffix"
 )
 
-// Cardinality limits to prevent excessive metric series
+// Cardinality limits: only the top-N keys per metric are exported.
 const (
-	MaxTrackedDomains   = 20 // Keep only top 20 domains for pie chart
-	MaxTrackedIPs       = 20 // Keep only top 20 IPs for pie chart
-	MaxTrackedOutbounds = 10 // Keep only top 10 outbounds
-	MaxTrackedASNs      = 20 // Keep only top 20 ASNs
-	MaxTrackedCountries = 20 // Keep only top 20 countries
-	MaxTrackedCities    = 20 // Keep only top 20 cities
+	MaxTrackedDomains   = 20
+	MaxTrackedIPs       = 20
+	MaxTrackedOutbounds = 10
+	MaxTrackedASNs      = 20
+	MaxTrackedCountries = 20
+	MaxTrackedCities    = 20
 
-	// SafetyMaxKeys caps distinct keys held per metric as a memory backstop
-	// against high-cardinality bursts (e.g. random-subdomain floods). It sits far
+	// Caps distinct keys held per metric as a memory backstop against
+	// high-cardinality bursts (e.g. random-subdomain floods). It sits far
 	// above the exported top-N, so it never disturbs the series actually scraped.
 	SafetyMaxKeys = 10000
 )
@@ -43,10 +42,8 @@ type LogEntry struct {
 	ParsedIP  net.IP
 }
 
-// windowedCount tracks a per-key request count together with the last time the
-// key was seen. Keeping last-seen lets idle keys be expired out of the time
-// window instead of being dropped by rank, which discarded live keys' history
-// and let stale winners stick around forever.
+// A per-key request count together with the last time the key was seen, so
+// idle keys can be expired out of the time window.
 type windowedCount struct {
 	count    int64
 	lastSeen time.Time
@@ -55,24 +52,24 @@ type windowedCount struct {
 // Holds collected metrics for a specified time window.
 // Uses a circular buffer for connection timestamps to prevent memory growth.
 type MetricsData struct {
-	UniqueIPs      map[string]time.Time      // IP -> last seen time
-	DomainCounts   map[string]*windowedCount // domain -> count + last seen
-	IPCounts       map[string]*windowedCount // direct IP requests -> count + last seen
-	OutboundCounts map[string]*windowedCount // outbound -> count + last seen
-	ASNCounts      map[string]*windowedCount // ASN -> count + last seen (key: asn|org)
-	CountryCounts  map[string]*windowedCount // country -> count + last seen (labels: country)
-	CityCounts     map[string]*windowedCount // city -> count + last seen (labels: city, country)
+	UniqueIPs      map[string]time.Time // IP -> last seen time.
+	DomainCounts   map[string]*windowedCount
+	IPCounts       map[string]*windowedCount // direct-IP requests.
+	OutboundCounts map[string]*windowedCount
+	ASNCounts      map[string]*windowedCount // key format: asn|org.
+	CountryCounts  map[string]*windowedCount
+	CityCounts     map[string]*windowedCount // key format: city|country.
 
 	// Circular buffer for connection timestamps to limit memory usage.
 	// The backing slice grows lazily up to ConnectionsBufCap so low-traffic
 	// servers don't pay the full allocation upfront.
-	ConnectionTimestamps []time.Time // circular buffer of connection timestamps
-	ConnectionsBufHead   int         // current write position in buffer
-	ConnectionsBufSize   int         // number of in-window entries currently held
-	ConnectionsBufCap    int         // maximum buffer capacity
+	ConnectionTimestamps []time.Time
+	ConnectionsBufHead   int // current write position in buffer.
+	ConnectionsBufSize   int // number of in-window entries currently held.
+	ConnectionsBufCap    int // maximum buffer capacity.
 
-	LastPos   int64  // last position read in log file
-	LastInode uint64 // last inode of log file (for rotation detection)
+	LastPos   int64  // last position read in log file.
+	LastInode uint64 // last inode of log file, for rotation detection.
 	mu        sync.RWMutex
 }
 
@@ -87,7 +84,6 @@ type Parser struct {
 	cancel     context.CancelFunc
 	mu         sync.Mutex
 
-	// GeoIP readers for real-time tracking
 	asnReader     *geoip2.Reader
 	countryReader *geoip2.Reader
 	cityReader    *geoip2.Reader
@@ -102,7 +98,6 @@ type Config struct {
 	CityReader    *geoip2.Reader
 }
 
-// Regular expressions for parsing different log line formats
 var (
 	timestampRegex   = regexp.MustCompile(`^(\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2})`)
 	newFormatIPRegex = regexp.MustCompile(`from (?:tcp:)?(\d+\.\d+\.\d+\.\d+|\S+):`)
@@ -110,9 +105,9 @@ var (
 	outboundRegex    = regexp.MustCompile(`\[[^\]]*?(?:->|>>)\s*([^\]]+?)\]`)
 )
 
-// metricsDelta accumulates a batch of parsed results so the expensive parsing
-// and GeoIP lookups can run WITHOUT holding the metrics lock. The deltas are
-// merged into the shared MetricsData under a brief lock at the end of a batch.
+// Accumulates a batch of parsed results so the expensive parsing and GeoIP
+// lookups can run without holding the metrics lock. The deltas are merged into
+// the shared MetricsData under a brief lock at the end of a batch.
 type metricsDelta struct {
 	domainCounts   map[string]*windowedCount
 	ipCounts       map[string]*windowedCount
@@ -136,7 +131,7 @@ func newMetricsDelta() *metricsDelta {
 	}
 }
 
-// recordCount increments the per-key count in m and advances its last-seen time.
+// Increments the per-key count in m and advances its last-seen time.
 func recordCount(m map[string]*windowedCount, key string, ts time.Time) {
 	wc := m[key]
 	if wc == nil {
@@ -150,24 +145,21 @@ func recordCount(m map[string]*windowedCount, key string, ts time.Time) {
 }
 
 // Performs quick checks to skip obviously invalid lines before expensive parsing.
-// Improves performance by filtering out non-log lines early.
 func shouldSkipLine(line string) bool {
-	// Skip empty or very short lines
-	if len(line) < 19 { // "2024/01/01 00:00:00" is 19 chars minimum
+	if len(line) < 19 { // "2024/01/01 00:00:00" is 19 chars minimum.
 		return true
 	}
 
-	// Quick check for timestamp pattern at start
+	// Cheap check for a timestamp shape at the start.
 	if len(line) < 4 || line[0] < '1' || line[0] > '9' || line[4] != '/' {
 		return true
 	}
 
-	// Skip comment lines
 	if strings.HasPrefix(line, "#") {
 		return true
 	}
 
-	// Must contain "from" for IP extraction
+	// Must contain "from" for IP extraction.
 	if !strings.Contains(line, "from ") {
 		return true
 	}
@@ -176,8 +168,7 @@ func shouldSkipLine(line string) bool {
 }
 
 // Extracts the registrable (eTLD+1) domain from a full domain name, using the
-// public suffix list so multi-part suffixes are handled correctly.
-// Example: a.sub.example.co.uk -> example.co.uk
+// public suffix list so multi-part suffixes like example.co.uk survive.
 func getRootDomain(domain string) string {
 	if domain == "" {
 		return ""
@@ -221,7 +212,7 @@ func (p *Parser) addConnectionTimestamp(ts time.Time) {
 	}
 }
 
-// Helper struct for sorting map entries by count
+// Pairs a metric key with its count for sorting.
 type countEntry struct {
 	key   string
 	count int64
@@ -293,24 +284,21 @@ func (p *Parser) expireWindowed(cutoff time.Time) {
 	}
 }
 
-// Keeps only the top N entries by count from a map
+// Keeps only the top n entries by count from a map.
 func keepTopN(counts map[string]int64, n int) map[string]int64 {
 	if len(counts) <= n {
 		return counts
 	}
 
-	// Convert to slice for sorting
 	entries := make([]countEntry, 0, len(counts))
 	for key, count := range counts {
 		entries = append(entries, countEntry{key: key, count: count})
 	}
 
-	// Sort by count (descending)
 	slices.SortFunc(entries, func(a, b countEntry) int {
 		return cmp.Compare(b.count, a.count)
 	})
 
-	// Keep only top N
 	result := make(map[string]int64, n)
 	for _, entry := range entries[:n] {
 		result[entry.key] = entry.count
@@ -331,13 +319,13 @@ func NewParser(config Config) (*Parser, error) {
 	var bufferCap int
 	switch {
 	case minutes <= 5:
-		bufferCap = 500000 // Short windows: up to 500K entries (~12MB)
+		bufferCap = 500000 // ~12MB.
 	case minutes <= 10:
-		bufferCap = 1000000 // Medium windows: up to 1M entries (~24MB)
+		bufferCap = 1000000 // ~24MB.
 	case minutes <= 30:
-		bufferCap = 2000000 // Long windows: up to 2M entries (~48MB)
+		bufferCap = 2000000 // ~48MB.
 	default:
-		bufferCap = 5000000 // Very long windows: up to 5M entries (~120MB)
+		bufferCap = 5000000 // ~120MB.
 	}
 
 	// Start small and let the buffer grow with traffic.
@@ -376,7 +364,7 @@ func (p *Parser) Start() error {
 	return nil
 }
 
-// Gracefully stops the log parser.
+// Stops background log monitoring.
 func (p *Parser) Stop() {
 	p.cancel()
 }
@@ -462,8 +450,8 @@ func (p *Parser) GetCityCounts() map[string]int64 {
 	return snapshotCounts(p.metrics.CityCounts)
 }
 
-// snapshotCounts returns a plain key->count copy, dropping the last-seen
-// bookkeeping so callers (the exporter) keep working with map[string]int64.
+// Returns a plain key->count copy, dropping the last-seen bookkeeping so
+// callers (the exporter) keep working with map[string]int64.
 func snapshotCounts(m map[string]*windowedCount) map[string]int64 {
 	out := make(map[string]int64, len(m))
 	for k, v := range m {
@@ -537,7 +525,6 @@ func (p *Parser) parseLogFile() error {
 	startPos := p.metrics.LastPos
 	p.mu.Unlock()
 
-	// Seek to last known position
 	if _, err := file.Seek(startPos, 0); err != nil {
 		return err
 	}
@@ -568,7 +555,6 @@ func (p *Parser) parseLogFile() error {
 	p.mergeDelta(delta)
 	p.metrics.mu.Unlock()
 
-	// Update file position for next read.
 	p.mu.Lock()
 	p.metrics.LastPos = newPos
 	p.mu.Unlock()
@@ -576,11 +562,10 @@ func (p *Parser) parseLogFile() error {
 	return nil
 }
 
-// processLine parses a single log line and records its data into delta.
+// Parses a single log line and records its data into delta.
 // It performs no shared-state mutation (the IP filter and GeoIP readers are
 // safe for concurrent use), so it can run without holding the metrics lock.
 func (p *Parser) processLine(line string, cutoff time.Time, delta *metricsDelta) {
-	// Quick pre-filtering to skip obviously invalid lines
 	if shouldSkipLine(line) {
 		return
 	}
@@ -607,21 +592,18 @@ func (p *Parser) processLine(line string, cutoff time.Time, delta *metricsDelta)
 		recordCount(delta.outboundCounts, outbound, entry.Timestamp)
 	}
 
-	// Skip entries outside time window (for user metrics only).
+	// User metrics below are time-windowed: skip entries outside the window.
 	if entry.Timestamp.Before(cutoff) {
 		return
 	}
 
-	// Filter out internal/system IPs.
 	if p.ipFilter.ShouldFilter(entry.IP) {
 		return
 	}
 
-	// Update user metrics (time-windowed).
 	delta.timestamps = append(delta.timestamps, entry.Timestamp)
 	delta.uniqueIPs[entry.IP] = entry.Timestamp
 
-	// Extract context for detailed tracking.
 	countryCode := "unknown"
 	cityName := "unknown"
 	asn := "unknown"
@@ -651,18 +633,17 @@ func (p *Parser) processLine(line string, cutoff time.Time, delta *metricsDelta)
 		}
 	}
 
-	// Update aggregated metrics.
 	if countryCode != "unknown" {
 		recordCount(delta.countryCounts, countryCode, entry.Timestamp)
 	}
 	if cityName != "unknown" {
 		recordCount(delta.cityCounts, cityName+"|"+countryCode, entry.Timestamp)
 	}
-	// Key format: asn|org
+	// Key format: asn|org.
 	recordCount(delta.asnCounts, asn+"|"+org, entry.Timestamp)
 }
 
-// mergeDelta folds a parsed batch into the shared metrics. Caller must hold metrics.mu.
+// Folds a parsed batch into the shared metrics. Caller must hold metrics.mu.
 func (p *Parser) mergeDelta(d *metricsDelta) {
 	mergeCounts(p.metrics.DomainCounts, d.domainCounts)
 	mergeCounts(p.metrics.IPCounts, d.ipCounts)
@@ -678,7 +659,7 @@ func (p *Parser) mergeDelta(d *metricsDelta) {
 	}
 }
 
-// mergeCounts folds src into dst, summing counts and keeping the latest last-seen.
+// Folds src into dst, summing counts and keeping the latest last-seen.
 func mergeCounts(dst, src map[string]*windowedCount) {
 	for k, v := range src {
 		wc := dst[k]
@@ -695,10 +676,9 @@ func mergeCounts(dst, src map[string]*windowedCount) {
 
 // Parses a single log line, extracting timestamp and client IP.
 func (p *Parser) parseLine(line string) (*LogEntry, error) {
-	// Parse timestamp
 	timestampMatch := timestampRegex.FindStringSubmatch(line)
 	if len(timestampMatch) < 2 {
-		return nil, nil // Skip lines without timestamp
+		return nil, nil // Skip lines without a timestamp.
 	}
 
 	// Xray writes local time, so parse in the local zone. Parsing as UTC would
@@ -708,26 +688,24 @@ func (p *Parser) parseLine(line string) (*LogEntry, error) {
 		return nil, err
 	}
 
-	// Extract IP with single pass through formats
 	var ip string
 	if match := newFormatIPRegex.FindStringSubmatch(line); len(match) > 1 {
 		ip = match[1]
 	} else if match := oldFormatIPRegex.FindStringSubmatch(line); len(match) > 1 {
 		if match[1] != "" {
-			ip = match[1] // IPv6
+			ip = match[1] // IPv6.
 		} else {
-			ip = match[2] // IPv4
+			ip = match[2] // IPv4.
 		}
 	}
 
 	if ip == "" {
-		return nil, nil // Skip lines without IP
+		return nil, nil // Skip lines without an IP.
 	}
 
-	// Normalize and parse the IP once, reusing the parsed value.
 	normalizedIP, parsedIP := normalizeIPParsed(ip)
 	if parsedIP == nil {
-		return nil, nil // Skip invalid IPs
+		return nil, nil // Skip invalid IPs.
 	}
 
 	return &LogEntry{
@@ -740,7 +718,6 @@ func (p *Parser) parseLine(line string) (*LogEntry, error) {
 // Performs a quick heuristic check for IP addresses without full parsing.
 // Avoids expensive net.ParseIP calls for obvious non-IP strings.
 func isIPAddressFast(s string) bool {
-	// Quick heuristic: if it contains only digits, dots, and colons, it might be an IP
 	for _, c := range s {
 		if !((c >= '0' && c <= '9') || c == '.' || c == ':' || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
 			return false
@@ -749,15 +726,14 @@ func isIPAddressFast(s string) bool {
 	return strings.Contains(s, ".") || strings.Contains(s, ":")
 }
 
-// Extracts domain with fewer string operations than the standard method.
+// Extracts the destination host from the "accepted tcp:host:port" segment of a log line.
 func extractDomainOptimized(line string) string {
-	// Look for "accepted" keyword first to avoid extracting from client part
+	// Search after "accepted" only, so the client address is never matched.
 	acceptedIdx := strings.Index(line, "accepted ")
 	if acceptedIdx == -1 {
 		return ""
 	}
 
-	// Search for tcp: or udp: patterns AFTER "accepted"
 	searchArea := line[acceptedIdx:]
 	tcpIdx := strings.Index(searchArea, "tcp:")
 	udpIdx := strings.Index(searchArea, "udp:")
@@ -771,7 +747,6 @@ func extractDomainOptimized(line string) string {
 		return ""
 	}
 
-	// Find space to end the domain:port section
 	spaceIdx := strings.Index(line[startIdx:], " ")
 	if spaceIdx == -1 {
 		return ""
@@ -779,7 +754,7 @@ func extractDomainOptimized(line string) string {
 
 	domainPort := line[startIdx : startIdx+spaceIdx]
 
-	// Find last colon to separate domain from port
+	// Last colon, so IPv6 literals keep their inner colons.
 	colonIdx := strings.LastIndex(domainPort, ":")
 	if colonIdx == -1 {
 		return ""
@@ -788,8 +763,8 @@ func extractDomainOptimized(line string) string {
 	return domainPort[:colonIdx]
 }
 
-// normalizeIPParsed canonicalizes an IP address string and returns both the
-// canonical string form and the parsed net.IP, so callers don't parse twice.
+// Canonicalizes an IP address string and returns both the canonical string
+// form and the parsed net.IP, so callers don't parse twice.
 func normalizeIPParsed(ip string) (string, net.IP) {
 	ip = strings.Trim(ip, "[]")
 

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ import (
 	"xray-exporter/internal/geoip"
 )
 
-// Command line configuration
 var opts struct {
 	Listen                 string `short:"l" long:"listen" description:"Listen address" value-name:"[ADDR]:PORT" default:":9550"`
 	MetricsPath            string `short:"m" long:"metrics-path" description:"Metrics path" value-name:"PATH" default:"/scrape"`
@@ -34,14 +33,13 @@ var opts struct {
 	LogFormat              string `long:"log-format" description:"Log format: text, json (env: LOG_FORMAT) (default: text)" value-name:"FORMAT"`
 }
 
-// Build information injected during compilation
+// Build information injected during compilation.
 var (
 	buildVersion = "dev"
 	buildCommit  = "none"
 	buildDate    = "unknown"
 )
 
-// Creates an HTTP handler for the Prometheus scrape endpoint
 func scrapeHandler(exporter *Exporter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		promhttp.HandlerFor(
@@ -50,7 +48,6 @@ func scrapeHandler(exporter *Exporter) http.HandlerFunc {
 	}
 }
 
-// Simple health check endpoint
 func healthHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write([]byte("OK")); err != nil {
@@ -58,7 +55,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// firstNonEmpty returns the first non-empty string, or "" if all are empty.
+// Returns the first non-empty string, or "" if all are empty.
 func firstNonEmpty(vals ...string) string {
 	for _, v := range vals {
 		if v != "" {
@@ -68,10 +65,9 @@ func firstNonEmpty(vals ...string) string {
 	return ""
 }
 
-// configureLogging sets the global logrus level and output format. For each,
-// precedence is the flag, then the env var, then the default (info level, text
-// format). Unrecognized values are non-fatal and fall back to the default, so a
-// typo never stops startup.
+// Sets the global logrus level and output format. For each, precedence is the
+// flag, then the env var, then the default (info level, text format).
+// Unrecognized values fall back to the default, so a typo never stops startup.
 func configureLogging(flagLevel, flagFormat string) {
 	levelStr := firstNonEmpty(flagLevel, os.Getenv("LOG_LEVEL"), "info")
 	var level logrus.Level
@@ -103,7 +99,6 @@ func configureLogging(flagLevel, flagFormat string) {
 }
 
 func main() {
-	// Parse command line arguments
 	if _, err := flags.Parse(&opts); err != nil {
 		if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
 			return
@@ -128,10 +123,8 @@ func main() {
 		logrus.WithError(err).Warn("Failed to initialize GeoIP database, GeoIP metrics will be unavailable")
 	}
 
-	// Initialize exporter with configuration
 	scrapeTimeout := time.Duration(opts.ScrapeTimeoutInSeconds) * time.Second
 
-	// Use default time window if not specified
 	timeWindowMinutes := opts.LogTimeWindowMinutes
 	if timeWindowMinutes == 0 {
 		timeWindowMinutes = DefaultLogTimeWindowMinutes
@@ -143,7 +136,6 @@ func main() {
 	}
 	defer exporter.Close()
 
-	// Set up HTTP routes
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc(opts.MetricsPath, scrapeHandler(exporter))
@@ -162,7 +154,6 @@ func main() {
 `, buildVersion, opts.MetricsPath)
 	})
 
-	// Configure HTTP server with reasonable timeouts
 	server := &http.Server{
 		Addr:         opts.Listen,
 		Handler:      mux,
@@ -181,7 +172,6 @@ func main() {
 		}
 	}()
 
-	// Wait for a shutdown signal or a server startup error.
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
@@ -194,7 +184,6 @@ func main() {
 
 	logrus.Info("Shutting down server...")
 
-	// Graceful shutdown with 30 second timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
Comment-only audit of all Go files. No logic, renames, or tests. The only non-comment diff is gofmt re-aligning the metric-description map literal in exporter.go.

## Deleted (~45)

- **Narration restating the code**: `// Parse command line arguments`, `// Set up HTTP routes`, `// Seek to last known position`, `// Parse timestamp`, `// Sort by count (descending)`, and similar in all files.
- **Redundant duplicates**: second/third package comments in exporter.go and filter.go (main.go and parser.go keep the package docs), file headers in inode_unix.go / inode_windows.go that repeated the function docs, the city-DB comment duplicating the warn log, the inline `circular buffer of connection timestamps` echoing the block comment above it.
- **Zero-content echoes**: `// Command line configuration`, doc comments on scrapeHandler/healthHandler and the three geoip path helpers, const comments like `// Keep only top 20 domains for pie chart`, struct field comments echoing the windowedCount type.
- **Misleading**: `// Class A/B/C private networks` labels on RFC 1918 CIDRs (the ranges are not classful classes).

## Rewritten (~10)

- `// GeoIP for ASN lookups` → covers all three readers (it was stale; city and country readers live there too).
- `Close` doc → mentions the GeoIP readers it also closes; dropped "Properly".
- `windowedCount` doc → dropped the changelog half describing the pre-refactor behavior.
- `extractDomainOptimized` doc → describes what it parses instead of comparing to a removed "standard method".
- `// Find last colon...` → now states the actual reason (IPv6 literals keep inner colons).
- gRPC connection comment → collapsed to the keepalive rationale.
- Name-first doc comments (`firstNonEmpty returns...`, `DownloadDB downloads...`, `mergeCounts folds...`, etc.) → reworded to start with a verb, content kept.
- Missing periods and casing normalized throughout.

## Kept unchanged

The comments carrying real constraints or non-obvious whys: panic containment in Collect, gauge-vs-counter rationale, per-user cardinality policy, stat-name format decode, scrape-deadline retry select, banner-vs-log-level note, atomic download rename, SafetyMaxKeys backstop, local-timezone parse, bufio.Reader/partial-line handling, throttled error logging, LRU concurrency notes, DNS server labels, NTFS file-index rationale.

## Verification

- `gofmt -l .` clean, `go build ./...` and `go vet ./...` pass (Windows + GOOS=linux cross-build).
- `golangci-lint run`: 11 issues, all pre-existing on main byte-for-byte (9 errcheck, 1 staticcheck, 1 unused) — untouched by this PR. CI lint only runs gofmt + vet, which pass.
- `go test ./...`: no test files exist in the repo.

Noticed while auditing (not changed here): `keepTopN` in internal/logparser/parser.go is dead code with no callers.